### PR TITLE
Update metadata for R 3.4 / 3.5

### DIFF
--- a/R/rtools-metadata.R
+++ b/R/rtools-metadata.R
@@ -55,11 +55,7 @@ version_info <- list(
   ),
   "3.4" = list(
     version_min = "3.3.0",
-    version_max = "3.4.99",
-    path = if (using_gcc49()) {
-      "bin"
-    } else {
-      c("bin", "gcc-4.6.3/bin")
-    }
+    version_max = "99.99.99",
+    path = "bin"
   )
 )


### PR DESCRIPTION
Fixes https://github.com/hadley/devtools/issues/1505

R versions >= 3.4 all use the gcc 4.9 toolchain, so we can remove the conditional for those versions.