### PR TITLE
Recompile when files in subdirectories have changed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,5 +5,7 @@
 
 * First argument of all functions is now `path` rather than `pkg`.
 
-
+* New global option `devtools.clean.compile.subdir.changes`. If it is
+  set to `TRUE`, any change in subdirectories trigger a complete
+  recompilation.
 

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -106,7 +106,11 @@ headers <- function(path = ".") {
 # Does the package need recompiling?
 # (i.e. is there a source or header file newer than the dll)
 needs_compile <- function(path = ".") {
-  source <- mtime(c(sources(path), headers(path)))
+  files <- c(sources(path), headers(path))
+  files_need_compile(files, path)
+}
+files_need_compile <- function(files, path) {
+  source <- mtime(files)
   # no source files, so doesn't need compile
   if (is.null(source)) return(FALSE)
 

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -5,7 +5,14 @@
 #' During compilation, debug flags are set with
 #' \code{\link{compiler_flags}(TRUE)}.
 #'
-#' Invisibly returns the names of the DLL.
+#' The build system normally only recompiles the files that were
+#' changed since the last build. However if a header or makefile has
+#' changed, the whole source is recompiled from scratch. Furthermore,
+#' if the `devtools.clean.compile.subdir.changes` global option is set
+#' to `TRUE`, any change in subdirectories trigger a complete
+#' recompilation.
+#'
+#' @return The names of the DLL, invisibly.
 #'
 #' @note If this is used to compile code that uses Rcpp, you will need to
 #'   add the following line to your \code{Makevars} file so that it

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -122,11 +122,15 @@ needs_compile <- function(path = ".") {
 needs_clean <- function(path = ".") {
   headers <- mtime(headers(path))
   # no headers, so never needs clean compile
-  if (is.null(headers)) return(FALSE)
+  if (is.null(headers)) {
+    return(FALSE)
+  }
 
   dll <- mtime(dll_path(path))
   # no dll, so needs compile
-  if (is.null(dll)) return(TRUE)
+  if (is.null(dll)) {
+    return(TRUE)
+  }
 
   headers > dll
 }
@@ -158,4 +162,3 @@ install_min <- function(path = ".", dest, components = NULL, args = NULL, quiet 
 
   invisible(file.path(dest, pkg_name(path)))
 }
-

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -124,6 +124,10 @@ files_need_compile <- function(files, path) {
 # Does the package need a clean compile?
 # (i.e. is there a header or Makevars newer than the dll)
 needs_clean <- function(path = ".") {
+  if (needs_subdir_clean(path)) {
+    return(TRUE)
+  }
+
   headers <- mtime(headers(path))
   # no headers, so never needs clean compile
   if (is.null(headers)) {
@@ -137,6 +141,18 @@ needs_clean <- function(path = ".") {
   }
 
   headers > dll
+}
+
+needs_subdir_clean <- function(path) {
+  if (!identical(getOption("devtools.clean.compile.subdir.changes"), TRUE)) {
+    return(FALSE)
+  }
+
+  srcdir <- file.path(path, "src")
+  subdirs <- list.dirs(srcdir, recursive = FALSE)
+  files <- dir(subdirs, "\\.(c.*|f)$", recursive = TRUE, full.names = TRUE)
+
+  files_need_compile(files, path)
 }
 
 install_min <- function(path = ".", dest, components = NULL, args = NULL, quiet = FALSE) {

--- a/man/compile_dll.Rd
+++ b/man/compile_dll.Rd
@@ -11,6 +11,9 @@ compile_dll(path = ".", quiet = FALSE)
 
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
 }
+\value{
+The names of the DLL, invisibly.
+}
 \description{
 \code{compile_dll} performs a fake R CMD install so code that
 works here should work with a regular install (and vice versa).
@@ -18,7 +21,12 @@ During compilation, debug flags are set with
 \code{\link{compiler_flags}(TRUE)}.
 }
 \details{
-Invisibly returns the names of the DLL.
+The build system normally only recompiles the files that were
+changed since the last build. However if a header or makefile has
+changed, the whole source is recompiled from scratch. Furthermore,
+if the `devtools.clean.compile.subdir.changes` global option is set
+to `TRUE`, any change in subdirectories trigger a complete
+recompilation.
 }
 \note{
 If this is used to compile code that uses Rcpp, you will need to


### PR DESCRIPTION
I made it optional (global option `devtools.clean.compile.subdir.changes`) and disabled by default.

https://github.com/r-lib/pkgload/issues/50 for context.