### PR TITLE
Disable spinner when building

### DIFF
--- a/R/rcmd.R
+++ b/R/rcmd.R
@@ -21,7 +21,7 @@ rcmd_build_tools <- function(..., env = character(), required = TRUE) {
   env <- c(callr::rcmd_safe_env(), env)
 
   with_build_tools(
-    callr::rcmd_safe(..., env = env),
+    callr::rcmd_safe(..., env = env, spinner = FALSE),
     required = required
   )
 }


### PR DESCRIPTION
As suggested by @gaborcsardi as it is a bit distracting and not very useful in that context.