### PR TITLE
compressing data when building package

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # pkgbuild 0.0.0.9000
 
+* `build()` only uses the `--no-resave-data` argument in `R CMD build`
+  if the `--resave-data` argument wasn't supplied by the user
+  (@theGreatWhiteShark, #26)
+
 * `build()` now cleans existing vignette files in `inst/doc` if they exist. (#10)
 
 * `clean_dll()` also deletes `symbols.rds` which is created when `compile_dll()`

--- a/R/build.r
+++ b/R/build.r
@@ -40,7 +40,9 @@ build <- function(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE
     args <- c("--build", args)
     cmd <- "INSTALL"
   } else {
-    args <- c(args, "--no-resave-data")
+    if ( ! "--resave-data" %in% args ){
+      args <- c(args, "--no-resave-data")
+    }
 
     if (manual && !has_latex()) {
       message("pdflatex not found! Not building PDF manual.")


### PR DESCRIPTION
the `build` function now only adds the `--no-resave-data` argument to the call of `R CMD build` if the `--resave-data` argument was not provided by the user.

Else the option specified by the user would be overwritten and no compression could be requested.

This commit fixes issue #26 