### PR TITLE
Simple test forcing color diagnostics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Description: You need a little help to reliably compile C code and build
     packages across platforms. This package provides such help.
 Imports:
     callr,
+    crayon,
     desc,
     rprojroot,
     withr

--- a/R/build.r
+++ b/R/build.r
@@ -77,16 +77,18 @@ build <- function(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE
 
   path <- normalizePath(path)
 
-  withr::with_temp_libpaths(
-    rcmd_build_tools(
-      cmd,
-      c(path, args),
-      wd = out_dir,
-      show = !quiet,
-      echo = !quiet,
-      fail_on_status = TRUE,
-      required = FALSE # already checked above
-    )
+  withr::with_makevars(compiler_flags(FALSE),
+    withr::with_temp_libpaths(
+      rcmd_build_tools(
+        cmd,
+        c(path, args),
+        wd = out_dir,
+        show = !quiet,
+        echo = !quiet,
+        fail_on_status = TRUE,
+        required = FALSE # already checked above
+        )
+      )
   )
 
   out_file <- dir(out_dir)

--- a/R/cache.R
+++ b/R/cache.R
@@ -15,7 +15,7 @@ cache_set <- function(name, value) {
   assign(name, value, envir = cache)
 }
 
-cache_remote <- function(name) {
+cache_remove <- function(name) {
   rm(list = name, envir = cache)
 }
 

--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -31,7 +31,7 @@ compile_dll <- function(path = ".", quiet = FALSE) {
   install_dir <- tempfile("devtools_install_")
   dir.create(install_dir)
 
-  withr::with_envvar(compiler_flags(TRUE), action = "prefix", {
+  withr::with_makevars(compiler_flags(TRUE), assignment = "+=", {
     install_min(
       path,
       dest = install_dir,

--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -39,7 +39,7 @@ compiler_flags <- function(debug = FALSE) {
     )
   }
 
-  if (has_compiler_colored_diagnostics()) {
+  if (crayon::has_color() && has_compiler_colored_diagnostics()) {
     res[c("CFLAGS", "CXXFLAGS", "CXX11FLAGS")] <-
       paste(res[c("CFLAGS", "CXXFLAGS", "CXX11FLAGS")], "-fdiagnostics-color=always")
   }

--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -53,14 +53,15 @@ has_compiler_colored_diagnostics <- function() {
 
   # We cannot use the existing has_compiler setting, because it may not have
   # run with -fdiagnostics-color=always
-  cache_remove("has_compiler")
+  if (cache_exists("has_compiler")) {
+    old <- cache_get("has_compiler")
+    cache_remove("has_compiler")
+    on.exit(cache_set("has_compiler", old))
+  } else {
+    on.exit(cache_remove("has_compiler"))
+  }
 
   res <- withr::with_makevars(c(CFLAGS = "-fdiagnostics-color=always"), has_compiler())
-
-  # We also do not want to retain the setting, because the call may have
-  # failed because there was no support for color diagnostics.
-  cache_remove("has_compiler")
-
 
   cache_set("has_compiler_colored_diagnostics", res)
   res

--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -16,22 +16,36 @@
 #' compiler_flags()
 #' compiler_flags(TRUE)
 compiler_flags <- function(debug = FALSE) {
-  if (Sys.info()[["sysname"]] == "SunOS") {
+  res <-
+    if (Sys.info()[["sysname"]] == "SunOS") {
     c(
       CFLAGS   = "-g",
-      CXXFLAGS = "-g"
+      CXXFLAGS = "-g",
+      CXX11FLAGS = "-g"
     )
   } else if (debug) {
     c(
-      CFLAGS   = "-UNDEBUG -Wall -pedantic -g -O0 -fdiagnostics-color=always",
-      CXXFLAGS = "-UNDEBUG -Wall -pedantic -g -O0 -fdiagnostics-color=always",
+      CFLAGS   = "-UNDEBUG -Wall -pedantic -g -O0",
+      CXXFLAGS = "-UNDEBUG -Wall -pedantic -g -O0",
+      CXX11FLAGS = "-UNDEBUG -Wall -pedantic -g -O0",
       FFLAGS   = "-g -O0",
       FCFLAGS  = "-g -O0"
     )
   } else {
     c(
-      CFLAGS   = "-Wall -pedantic -fdiagnostics-color=always",
-      CXXFLAGS = "-Wall -pedantic -fdiagnostics-color=always"
+      CFLAGS   = "-Wall -pedantic",
+      CXXFLAGS = "-Wall -pedantic",
+      CXX11FLAGS = "-Wall -pedantic"
     )
   }
+
+  if (has_compiler_colored_diagnostics()) {
+    res[c("CFLAGS", "CXXFLAGS", "CXX11FLAGS")] <-
+      paste(res[c("CFLAGS", "CXXFLAGS", "CXX11FLAGS")], "-fdiagnostics-color=always")
+  }
+  res
+}
+
+has_compiler_colored_diagnostics <- function() {
+  withr::with_makevars(c(CFLAGS = "-fdiagnostics-color=always"), has_compiler())
 }

--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -23,15 +23,15 @@ compiler_flags <- function(debug = FALSE) {
     )
   } else if (debug) {
     c(
-      CFLAGS   = "-UNDEBUG -Wall -pedantic -g -O0 -fcolor-diagnostics",
-      CXXFLAGS = "-UNDEBUG -Wall -pedantic -g -O0 -fcolor-diagnostics",
+      CFLAGS   = "-UNDEBUG -Wall -pedantic -g -O0 -fdiagnostics-color=always",
+      CXXFLAGS = "-UNDEBUG -Wall -pedantic -g -O0 -fdiagnostics-color=always",
       FFLAGS   = "-g -O0",
       FCFLAGS  = "-g -O0"
     )
   } else {
     c(
-      CFLAGS   = "-Wall -pedantic -fcolor-diagnostics",
-      CXXFLAGS = "-Wall -pedantic -fcolor-diagnostics"
+      CFLAGS   = "-Wall -pedantic -fdiagnostics-color=always",
+      CXXFLAGS = "-Wall -pedantic -fdiagnostics-color=always"
     )
   }
 }

--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -46,6 +46,12 @@ compiler_flags <- function(debug = FALSE) {
   res
 }
 
-has_compiler_colored_diagnostics <- function() {
-  withr::with_makevars(c(CFLAGS = "-fdiagnostics-color=always"), has_compiler())
-}
+has_compiler_colored_diagnostics <- local({
+  res <- NULL
+  function() {
+    if (is.null(res)) {
+      res <<- withr::with_makevars(c(CFLAGS = "-fdiagnostics-color=always"), has_compiler())
+    }
+    res
+  }
+})

--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -23,15 +23,15 @@ compiler_flags <- function(debug = FALSE) {
     )
   } else if (debug) {
     c(
-      CFLAGS   = "-UNDEBUG -Wall -pedantic -g -O0",
-      CXXFLAGS = "-UNDEBUG -Wall -pedantic -g -O0",
+      CFLAGS   = "-UNDEBUG -Wall -pedantic -g -O0 -fcolor-diagnostics",
+      CXXFLAGS = "-UNDEBUG -Wall -pedantic -g -O0 -fcolor-diagnostics",
       FFLAGS   = "-g -O0",
       FCFLAGS  = "-g -O0"
     )
   } else {
     c(
-      CFLAGS   = "-Wall -pedantic",
-      CXXFLAGS = "-Wall -pedantic"
+      CFLAGS   = "-Wall -pedantic -fcolor-diagnostics",
+      CXXFLAGS = "-Wall -pedantic -fcolor-diagnostics"
     )
   }
 }

--- a/tests/testthat/test-compile_dll.R
+++ b/tests/testthat/test-compile_dll.R
@@ -1,7 +1,7 @@
 context("compile_dll")
 
 test_that("can compile a DLL and clean up afterwards", {
-  expect_error(compile_dll("testWithSrc", quiet = TRUE), NA)
+  expect_error(compile_dll("testWithSrc", quiet = FALSE), NA)
 
   clean_dll("testWithSrc")
   expect_equal(dir("testWithSrc/src"), "add1.c")


### PR DESCRIPTION
This works, however some parts still to be addressed

- [x] - Should only add diagnostics if a color supported terminal.
- [x] - Do we need to check the compiler version (might be tricky to do)
- [x] - Is unconditionally adding `-Wall -pedantic` going to be a problem (I don't think so...)

Also the previous code was adding the compiler flags as environment variables, which actually has no effect, they need to be in a Makevars file to effect the R compilation.