### PR TITLE
update DESCRIPTION URLs to point to r-lib not r-pkgs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,8 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
-URL: https://github.com/r-pkgs/pkgbuild
-BugReports: https://github.com/r-pkgs/pkgbuild/issues
+URL: https://github.com/r-lib/pkgbuild
+BugReports: https://github.com/r-lib/pkgbuild/issues
 Roxygen: list(markdown = TRUE)
 Depends: 
     R (>= 3.1)


### PR DESCRIPTION
Feel free to ignore, but just saw this and thought it might be useful!