### PR TITLE
Fix typos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Suggests:
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 URL: https://github.com/r-lib/pkgbuild
 BugReports: https://github.com/r-lib/pkgbuild/issues
 Roxygen: list(markdown = TRUE)

--- a/R/build-tools.R
+++ b/R/build-tools.R
@@ -8,7 +8,7 @@
 #'
 #' Errors like `running command
 #' '"C:/PROGRA~1/R/R-34~1.2/bin/x64/R" CMD config CC' had status 127`
-#' indicate the code expected RTools to be on the system PATH. You can
+#' indicate the code expected Rtools to be on the system PATH. You can
 #' then verify you have rtools installed with `has_build_tools()` and
 #' temporarily add Rtools to the PATH `with_build_tools({ code })`.
 #'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pkgbuild::check_build_tools(debug = TRUE)
 # Build a package
 pkgbuild::build("/path/to/my/package")
 
-# Run your own code in an environment guarnteed to 
+# Run your own code in an environment guaranteed to 
 # have build tools available
 pkgbuild::with_build_tools(my_code)
 ```

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -4,9 +4,9 @@
 \alias{build}
 \title{Build package}
 \usage{
-build(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE,
-  manual = FALSE, args = NULL, quiet = FALSE, needs_compilation = NA,
-  compile_attributes = TRUE)
+build(path = ".", dest_path = NULL, binary = FALSE,
+  vignettes = TRUE, manual = FALSE, args = NULL, quiet = FALSE,
+  needs_compilation = NA, compile_attributes = TRUE)
 }
 \arguments{
 \item{path}{Path to a package, or within a package.}

--- a/man/compiler_flags.Rd
+++ b/man/compiler_flags.Rd
@@ -27,3 +27,4 @@ compiler_flags(TRUE)
 \seealso{
 Other debugging flags: \code{\link{with_debug}}
 }
+\concept{debugging flags}

--- a/man/has_build_tools.Rd
+++ b/man/has_build_tools.Rd
@@ -32,7 +32,7 @@ available these functions will trigger an automated install.
 }
 \details{
 Errors like \code{running command '"C:/PROGRA~1/R/R-34~1.2/bin/x64/R" CMD config CC' had status 127}
-indicate the code expected RTools to be on the system PATH. You can
+indicate the code expected Rtools to be on the system PATH. You can
 then verify you have rtools installed with \code{has_build_tools()} and
 temporarily add Rtools to the PATH \code{with_build_tools({ code })}.
 

--- a/man/with_debug.Rd
+++ b/man/with_debug.Rd
@@ -36,3 +36,4 @@ with_debug(install("mypkg"))
 \seealso{
 Other debugging flags: \code{\link{compiler_flags}}
 }
+\concept{debugging flags}


### PR DESCRIPTION
Fixes two typos, one in a comment in README.md, one ("RTools" vs. "Rtools") in build-tools.R. roxygen2::roxygenise() made some more changes, which I can revert if necessary. 