### PR TITLE
Add -std=gnu99 to CFLAGS on Windows

### DIFF
--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -39,6 +39,10 @@ compiler_flags <- function(debug = FALSE) {
     )
   }
 
+  if (Sys.info()[["sysname"]] == "Windows") {
+    res["CFLAGS"] <- paste(res["CFLAGS"], "-std=gnu99")
+  }
+
   if (crayon::has_color() && has_compiler_colored_diagnostics()) {
     res[c("CFLAGS", "CXXFLAGS", "CXX11FLAGS")] <-
       paste(res[c("CFLAGS", "CXXFLAGS", "CXX11FLAGS")], "-fdiagnostics-color=always")


### PR DESCRIPTION
I found AppVeyor keeps failing on tibble repo and it seems this is because of the absense of `-std=gnu99`: https://github.com/tidyverse/tibble/issues/485

pkgbuild defines `CFLAGS` by itself, but Windows seems to need `-std=gnu99` as the default is so.

```ps1
PS C:\...> R.exe CMD config CFLAGS
-O2 -Wall -std=gnu99 -mtune=generic

PS C:\...> R.exe CMD config CXXFLAGS
-O2 -Wall -mtune=generic

PS C:\...> R.exe CMD config CXX11FLAGS
-O2 -Wall -mtune=generic
```
