### PR TITLE
Do not customize compiler flags for pkgbuild_process

### DIFF
--- a/R/build-bg.R
+++ b/R/build-bg.R
@@ -56,10 +56,7 @@ pkgbuild_process <- R6Class(
       rcb_init(self, private, super, path, dest_path, binary, vignettes,
                manual, args, needs_compilation, compile_attributes, register_routines),
 
-    finalize = function() {
-      super$kill()
-      tryCatch(unlink(private$makevars_file), error = function(x) x)
-    },
+    finalize = function() super$kill(),
 
     get_dest_path = function() private$dest_path,
 
@@ -79,17 +76,12 @@ pkgbuild_process <- R6Class(
       private$out_file
     },
 
-    kill = function(...) {
-      ret <- super$kill(...)
-      tryCatch(unlink(private$makevars_file), error = function(x) x)
-      ret
-    }
+    kill = function(...) super$kill(...)
   ),
 
   private = list(
     path = NULL,
     dest_path = NULL,
-    makevars_file = NULL,
     out_dir = NULL,
     out_file = NULL
   )
@@ -116,14 +108,7 @@ rcb_init <- function(self, private, super, path, dest_path, binary,
     wd = options$out_dir
   )
 
-  ## We cannot use withr::with_makevars directly, because that removes
-  ## Makevars when exiting
-  flags <- compiler_flags(FALSE)
-  private$makevars_file <- tempfile()
-  withr::with_envvar(c(R_MAKEVARS_USER = private$makevars_file), {
-    withr::set_makevars(flags, new_path = private$makevars_file)
-    super$initialize(options)
-  })
+  super$initialize(options)
 
   invisible(self)
 }

--- a/tests/testthat/test-build-process.r
+++ b/tests/testthat/test-build-process.r
@@ -116,29 +116,10 @@ test_that("can kill a build process", {
   ret <- pr$kill()
   if (!ret) skip("build finished before we could kill it")
 
-  makevars_file <- pr$.__enclos_env__$private$makevars_file
-  expect_false(is.null(makevars_file))
-  if (!is.null(makevars_file)) expect_false(file.exists(makevars_file))
-
   ex_stat <- pr$get_exit_status()
   if (.Platform$OS.type == "unix") {
     expect_equal(ex_stat, -9)
   } else {
     expect_true(ex_stat != 0)
   }
-})
-
-test_that("temp makevars file is cleaned up", {
-  skip_on_cran()
-  dir.create(tmp <- tempfile())
-  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
-
-  pr <- pkgbuild_process$new("testDummy", dest_path = tmp)
-  makevars_file <- pr$.__enclos_env__$private$makevars_file
-  expect_false(is.null(makevars_file))
-  expect_true(file.exists(makevars_file))
-
-  rm(pr)
-  gc()
-  expect_false(file.exists(makevars_file))
 })


### PR DESCRIPTION
Instead just use the user's Makevars file.

Closes #76.