### PR TITLE
Redirect stderr to stdout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Provides functions used to build R packages. Locates compilers
   needed to build R packages on various platforms and ensures the PATH is
   configured appropriately so R can use them.
 Imports:
-    callr (>= 2.0.0),
+    callr (>= 3.2.0),
     cli,
     crayon,
     desc,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 * `pkgbuild_process` now do not set custom compiler flags, and it uses
   the user's `Makevars` file (@gaborcsardi, #76).
 
+* Make sure that standard output and error are correctly interleaved in
+  `build()` and `pkgbuild_process`, by redirecting the standard error of
+  build process to the standard output (@gaborcsardi, #78).
+
 # pkgbuild 1.0.3
 
 * Tests which wrote to the package library are now skipped on CRAN.

--- a/R/build-bg.R
+++ b/R/build-bg.R
@@ -58,6 +58,12 @@ pkgbuild_process <- R6Class(
 
     finalize = function() super$kill(),
 
+    is_incomplete_error = function() FALSE,
+    read_all_error = function() "",
+    read_all_error_lines = function() character(),
+    read_error = function(n = -1) "",
+    read_error_lines = function(n = -1) character(),
+
     get_dest_path = function() private$dest_path,
 
     get_built_file = function() {
@@ -105,7 +111,8 @@ rcb_init <- function(self, private, super, path, dest_path, binary,
   options <- rcmd_process_options(
     cmd = options$cmd,
     cmdargs = c(options$path, options$args),
-    wd = options$out_dir
+    wd = options$out_dir,
+    stderr = "2>&1"
   )
 
   super$initialize(options)

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -33,7 +33,8 @@ has_compiler <- function(debug = FALSE) {
       wd = tempdir(),
       show = debug,
       echo = debug,
-      fail_on_status = TRUE
+      fail_on_status = TRUE,
+      stderr = "2>&1"
     )
 
     if (debug)

--- a/R/rcmd.R
+++ b/R/rcmd.R
@@ -25,7 +25,7 @@ rcmd_build_tools <- function(..., env = character(), required = TRUE, quiet = FA
 
   res <- with_build_tools(
     callr::rcmd_safe(..., env = env, spinner = FALSE, show = FALSE,
-      echo = FALSE, block_callback = block_callback(quiet)),
+      echo = FALSE, block_callback = block_callback(quiet), stderr = "2>&1"),
     required = required
   )
 
@@ -36,7 +36,7 @@ rcmd_build_tools <- function(..., env = character(), required = TRUE, quiet = FA
 
 msg_for_long_paths <- function(output) {
   if (is_windows() &&
-      any(grepl("over-long path length", output$stderr))) {
+      any(grepl("over-long path length", output$stdout))) {
     message(
       "\nIt seems that this package contains files with very long paths.\n",
       "This is not supported on most Windows versions. Please contact the\n",


### PR DESCRIPTION
To make them correctly interleaved. This is both
for build() and pkgbuild_process.

Otherwise it is pretty hard to show meaningful output on error, especially for the background process. But the output of `build()` can also be out-of-order without this.

