### PR TITLE
Add support for msys2 and rtools40

### DIFF
--- a/R/rtools-metadata.R
+++ b/R/rtools-metadata.R
@@ -62,5 +62,10 @@ version_info <- list(
     version_min = "3.3.0",
     version_max = "99.99.99",
     path = "bin"
+  ),
+  "4.0" = list(
+    version_min = "3.7.0",
+    version_max = "99.99.99",
+    path = "bin"
   )
 )

--- a/R/rtools-path.R
+++ b/R/rtools-path.R
@@ -40,9 +40,15 @@ scan_path_for_rtools <- function(debug = FALSE) {
 }
 
 find_arch_exe <- function(path, debug = FALSE) {
-  # First try adding .exe
-  if (!file.exists(path)) {
-    path <- paste0(path, ".exe")
+  # Convert unix path to Windows
+  if(grepl("^/", path)){
+    path <- convert_unix_path(path)
+  }
+
+  # Sys.which normalizes relative/absolute path and adds .exe if needed.
+  full_path <- unname(Sys.which(path))
+  if(nchar(full_path)){
+    path <- full_path
   }
 
   if (!file.exists(path)) {
@@ -60,4 +66,8 @@ find_arch_exe <- function(path, debug = FALSE) {
   }
 
   path
+}
+
+convert_unix_path <- function(path){
+  system2("cygpath", c('-m', path), stdout = TRUE)
 }

--- a/R/rtools.R
+++ b/R/rtools.R
@@ -132,6 +132,9 @@ check_rtools <- function(debug = FALSE) {
 }
 
 installed_version <- function(path, debug) {
+  if(is_rtools40(path)){
+    return("4.0")
+  }
   if (!file.exists(file.path(path, "Rtools.txt"))) return(NULL)
 
   # Find the version path
@@ -185,6 +188,12 @@ rtools_needed <- function() {
       return(paste("Rtools", version))
   }
   "the appropriate version of Rtools"
+}
+
+is_rtools40 <- function(path){
+  path <- normalizePath(tolower(path), mustWork = FALSE)
+  rtools40_path <- tolower(Sys.getenv('RTOOLS40_HOME', "c:\\rtools40"))
+  grepl(rtools40_path, path, fixed = TRUE)
 }
 
 rtools_url <- "http://cran.r-project.org/bin/windows/Rtools/"


### PR DESCRIPTION
This adds support for rtools40 / msys2 build environments:

 - Use `RTOOLS40_HOME` variable (set by the rtools40 installer) to detect rtools40.
 - Understand msys2 unix paths such as `/mingw64/bin/gcc` 

Once the toolchain is in production we can further tweak this, but for now this should at least prevent check errors. 

Fixes #40, closes #44.