### PR TITLE
Fixes for rtools40

### DIFF
--- a/R/rtools-cache.R
+++ b/R/rtools-cache.R
@@ -21,7 +21,8 @@ rtools_path_set <- function(rtools) {
   path <- file.path(rtools$path, version_info[[rtools$version]]$path)
 
   # If using gcc49 and _without_ a valid BINPREF already set
-  if (using_gcc49() && is.null(rtools$valid_binpref)) {
+  # Do NOT set BINPREF anymore for R 4.0 / rtools40
+  if (!is_R4() && using_gcc49() && is.null(rtools$valid_binpref)) {
     Sys.setenv(BINPREF = file.path(rtools$path, "mingw_$(WIN)", "bin", "/"))
   }
 
@@ -29,5 +30,5 @@ rtools_path_set <- function(rtools) {
 }
 
 using_gcc49 <- function() {
-  isTRUE(sub("^gcc[^[:digit:]]+", "", Sys.getenv("R_COMPILED_BY")) >= "4.9.3")
+  grepl('4.9.3', Sys.getenv("R_COMPILED_BY"), fixed = TRUE)
 }

--- a/R/rtools-config.R
+++ b/R/rtools-config.R
@@ -3,7 +3,7 @@ scan_config_for_rtools <- function(debug = FALSE) {
   if (debug)
     cat("Scanning R CMD config CC...\n")
 
-  if (!using_gcc49())
+  if (!is_R4() && !using_gcc49())
     return()
 
   cc_path <- gsub("\n", "", callr::rcmd_safe("config", "CC")$stdout)
@@ -22,4 +22,8 @@ scan_config_for_rtools <- function(debug = FALSE) {
       cat("install_path:", install_path, "\n")
     rtools(install_path, "custom", valid_binpref = TRUE)
   }
+}
+
+is_R4 <- function(){
+  R.Version()$major >= "4"
 }

--- a/R/rtools-metadata.R
+++ b/R/rtools-metadata.R
@@ -55,22 +55,22 @@ version_info <- list(
   ),
   "3.4" = list(
     version_min = "3.3.0",
-    version_max = "99.99.99",
+    version_max = "3.6.3",
     path = "bin"
   ),
   "3.5" = list(
     version_min = "3.3.0",
-    version_max = "99.99.99",
+    version_max = "3.6.3",
     path = "bin"
   ),
   "4.0" = list(
-    version_min = "3.3.0",
+    version_min = "4.0.0",
     version_max = "99.99.99",
-    path = "bin"
+    path = "usr/bin"
   ),
   "custom" = list(
     version_min = "2.10.0",
     version_max = "99.99.99",
-    path = "bin"
+    path = "usr/bin"
   )
 )

--- a/R/rtools.R
+++ b/R/rtools.R
@@ -28,7 +28,17 @@ has_rtools <- function(debug = FALSE) {
   if (!is_windows())
     return(FALSE)
 
+  # In R 4.0 we can use RTOOLS40_HOME
+  if(is_R4()){
+    rtools40_home <- Sys.getenv('RTOOLS40_HOME')
+    if(nchar(rtools40_home) && file.exists(rtools40_home)){
+      rtools_path_set(rtools(rtools40_home, '4.0'))
+      return(TRUE)
+    }
+  }
+
   # First, R CMD config CC --------------------------------------------
+  # This does not work if 'make' is not yet on the path
   from_config <- scan_config_for_rtools(debug)
   if (is_compatible(from_config)) {
     if (debug)


### PR DESCRIPTION
Somewhat urgent, because there is a pretty bad bug where `using_gcc49()` returns `T` even when using gcc 8.3.0. 

R 4.0 has much improved defaults for `CC` and so on. It will automatically find the correct rtools40 path based on `RTOOLS40_HOME`. The best thing you can do is not change anything.

The one thing that pkgbuild may want to do is put `${RTOOLS40_HOME}\usr\bin` on the PATH if the user hasn't done so yet.
