### PR TITLE
Fix rtools_needed always returning custom

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # pkgbuild (development version)
 
 * `compile_dll()` now supports automatic cpp11 registration if the package links to cpp11.
+* `rtools_needed` returns correct version instead of "custom" (@burgerga, #97)
 
 # pkgbuild 1.0.8
 

--- a/R/rtools.R
+++ b/R/rtools.R
@@ -192,12 +192,13 @@ is.rtools <- function(x) inherits(x, "rtools")
 #'
 #' @keywords internal
 #' @export
-rtools_needed <- function() {
-  r_version <- getRversion()
+rtools_needed <- function(r_version = getRversion()) {
+  vi <- version_info
+  vi$custom <- NULL
 
-  for (i in rev(seq_along(version_info))) {
-    version <- names(version_info)[i]
-    info <- version_info[[i]]
+  for (i in rev(seq_along(vi))) {
+    version <- names(vi)[i]
+    info <- vi[[i]]
     ok <- r_version >= info$version_min && r_version <= info$version_max
     if (ok)
       return(paste("Rtools", version))

--- a/man/rtools_needed.Rd
+++ b/man/rtools_needed.Rd
@@ -4,7 +4,7 @@
 \alias{rtools_needed}
 \title{Retrieve a text string with the rtools version needed}
 \usage{
-rtools_needed()
+rtools_needed(r_version = getRversion())
 }
 \description{
 Retrieve a text string with the rtools version needed

--- a/tests/testthat/test-rtools.r
+++ b/tests/testthat/test-rtools.r
@@ -23,3 +23,12 @@ test_that("has_rtools finds rtools", {
       expect_true(rtools_path() != "")
     }))
 })
+
+test_that("rtools_needed works", {
+  skip_if_not(is_windows())
+
+  # Test only frozen versions
+  expect_equal(rtools_needed("3.6.3"), "Rtools 3.5")
+  expect_equal(rtools_needed("2.9"), "Rtools 3.0")
+  expect_equal(rtools_needed("0.0.0"), "the appropriate version of Rtools")
+})


### PR DESCRIPTION
Because the 'custom' entry in `version_info` has quite a large range and is checked first, `rtools_needed` always returned 'custom'. (as discussed in #97)

This fix:
- copies version_info to a local variable and removes custom
- sets r_version as function argument so the function can be unit tested
- adds unit tests for some frozen/bogus versions of R

All checks pass!