### PR TITLE
Enable control over debug for compile_dll

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgbuild (development version)
 
+* `compile_dll()` gains a `debug` argument for more control over the compile options used (@richfitz, #100)
+
 # pkgbuild 1.1.0
 
 * `compile_dll()` now supports automatic cpp11 registration if the package links to cpp11.

--- a/R/compile-dll.R
+++ b/R/compile-dll.R
@@ -15,13 +15,18 @@
 #' @inheritParams build
 #' @param force If `TRUE`, for compilation even if [needs_compile()] is
 #'   `FALSE`.
+#' @param debug If `TRUE`, and if no user Makevars is found, then the build
+#'   runs without optimisation (`-O0`) and with debug symbols (`-g`). See
+#'   [compiler_flags()] for details. If you have a user Makevars (e.g.,
+#'   `~/.R/Makevars`) then this argument is ignored.
 #' @seealso [clean_dll()] to delete the compiled files.
 #' @export
 compile_dll <- function(path = ".",
                         force = FALSE,
                         compile_attributes = pkg_links_to_cpp11(path) || pkg_links_to_rcpp(path),
                         register_routines = FALSE,
-                        quiet = FALSE) {
+                        quiet = FALSE,
+                        debug = TRUE) {
   path <- pkg_path(path)
 
   if (!needs_compile(path) && !isTRUE(force)) {
@@ -49,7 +54,7 @@ compile_dll <- function(path = ".",
     )
   } else {
     # Otherwise set makevars for fast development / debugging
-    withr::with_makevars(compiler_flags(TRUE), assignment = "+=", {
+    withr::with_makevars(compiler_flags(debug), assignment = "+=", {
       install_min(
         path,
         dest = install_dir,

--- a/man/compile_dll.Rd
+++ b/man/compile_dll.Rd
@@ -9,7 +9,8 @@ compile_dll(
   force = FALSE,
   compile_attributes = pkg_links_to_cpp11(path) || pkg_links_to_rcpp(path),
   register_routines = FALSE,
-  quiet = FALSE
+  quiet = FALSE,
+  debug = TRUE
 )
 }
 \arguments{
@@ -28,6 +29,11 @@ register routines with
 the package. It is ignored if package does not need compilation.}
 
 \item{quiet}{if \code{TRUE} suppresses output from this function.}
+
+\item{debug}{If \code{TRUE}, and if no user Makevars is found, then the build
+runs without optimisation (\code{-O0}) and with debug symbols (\code{-g}). See
+\code{\link[=compiler_flags]{compiler_flags()}} for details. If you have a user Makevars (e.g.,
+\verb{~/.R/Makevars}) then this argument is ignored.}
 }
 \description{
 \code{compile_dll} performs a fake R CMD install so code that


### PR DESCRIPTION
This PR enables the debug flags to be controlled for `compile_dll()`. At present if the user has a `~/.R/Makevars` (or equivalent) then the debug flags (`-O0 -g`) are not added, otherwise they are unconditionally added. I noticed this when code was behaving differently in a docker container to locally.

I have kept the default behaviour the same, though it might be better flipped, controlled by an option etc. Any thoughts on that would depend on this function's interaction with `load_all` and friends though.

I have not added tests (yet) because I am not sure you'd want to support this feature. If testing was added it would likely require pulling in mockery as a Suggests.

Motivation: I am using this within a package that loads user code - I need a bit more control than `cpp11::cpp_source` as I am also pairing a bit of R code with the compiled code and trying to keep the workflow as similar as a packaged workflow as possible. I notice that `cpp11::cpp_source` itself does not use `pkgbuild::compile_dll`, though it would run into this if it did.
