### PR TITLE
Enable colored compiler diagnostics with the background process as well

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pkgbuild (development version)
 
+* `pkgbuild_process()` and `build()` now use colored compiler diagnostics if supported (#102)
+
 # pkgbuild 1.1.0
 
 * `compile_dll()` now supports automatic cpp11 registration if the package links to cpp11.

--- a/R/build-bg.R
+++ b/R/build-bg.R
@@ -57,7 +57,10 @@ pkgbuild_process <- R6Class(
                manual, clean_doc, args, needs_compilation, compile_attributes,
                register_routines),
 
-    finalize = function() super$kill(),
+    finalize = function() {
+      unlink(private$makevars_file)
+      super$kill()
+    },
 
     is_incomplete_error = function() FALSE,
     read_all_error = function() "",
@@ -83,14 +86,18 @@ pkgbuild_process <- R6Class(
       private$out_file
     },
 
-    kill = function(...) super$kill(...)
+    kill = function(...) {
+      unlink(private$makevars_file)
+      super$kill(...)
+    }
   ),
 
   private = list(
     path = NULL,
     dest_path = NULL,
     out_dir = NULL,
-    out_file = NULL
+    out_file = NULL,
+    makevars_file = NULL
   )
 )
 
@@ -102,14 +109,17 @@ rcb_init <- function(self, private, super, path, dest_path, binary,
 
   options <- build_setup(path, dest_path, binary, vignettes, manual, clean_doc,
                          args, needs_compilation, compile_attributes,
-                         register_routines, quiet, env = self)
+                         register_routines, quiet)
 
   private$path <- options$path
   private$dest_path <- options$dest_path
   private$out_dir <- options$out_dir
+  private$makevars_file <- tempfile()
 
   ## Build tools already checked in setup
 
+  withr::set_makevars(compiler_flags(debug = FALSE), new_path = private$makevars_file, assignment = "+=")
+  withr::local_envvar("R_MAKEVARS_USER" = private$makevars_file)
   options <- rcmd_process_options(
     cmd = options$cmd,
     cmdargs = c(options$path, options$args),

--- a/R/build-bg.R
+++ b/R/build-bg.R
@@ -102,7 +102,7 @@ rcb_init <- function(self, private, super, path, dest_path, binary,
 
   options <- build_setup(path, dest_path, binary, vignettes, manual, clean_doc,
                          args, needs_compilation, compile_attributes,
-                         register_routines, quiet)
+                         register_routines, quiet, env = self)
 
   private$path <- options$path
   private$dest_path <- options$dest_path

--- a/R/build.R
+++ b/R/build.R
@@ -45,7 +45,7 @@ build <- function(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE
                          needs_compilation, compile_attributes, register_routines, quiet)
   on.exit(unlink(options$out_dir, recursive = TRUE), add = TRUE)
 
-  withr:::local_makevars(compiler_flags(debug = FALSE), .assignment = "+=")
+  withr::local_makevars(compiler_flags(debug = FALSE), .assignment = "+=")
   withr::with_temp_libpaths(
     rcmd_build_tools(
       options$cmd,

--- a/R/build.R
+++ b/R/build.R
@@ -64,7 +64,7 @@ build <- function(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE
 }
 
 build_setup <- function(path, dest_path, binary, vignettes, manual, clean_doc, args,
-                        needs_compilation, compile_attributes, register_routines, quiet) {
+                        needs_compilation, compile_attributes, register_routines, quiet, env = parent.frame()) {
 
   if (!file.exists(path)) {
     stop("`path` must exist", call. = FALSE)
@@ -87,6 +87,7 @@ build_setup <- function(path, dest_path, binary, vignettes, manual, clean_doc, a
 
   if (needs_compilation) {
     update_registration(path, compile_attributes, register_routines, quiet)
+    withr:::local_makevars(compiler_flags(debug = FALSE), assignment = "+=", .local_envir = env)
   }
 
   if (binary) {

--- a/R/build.R
+++ b/R/build.R
@@ -45,6 +45,7 @@ build <- function(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE
                          needs_compilation, compile_attributes, register_routines, quiet)
   on.exit(unlink(options$out_dir, recursive = TRUE), add = TRUE)
 
+  withr:::local_makevars(compiler_flags(debug = FALSE), .assignment = "+=")
   withr::with_temp_libpaths(
     rcmd_build_tools(
       options$cmd,
@@ -64,7 +65,7 @@ build <- function(path = ".", dest_path = NULL, binary = FALSE, vignettes = TRUE
 }
 
 build_setup <- function(path, dest_path, binary, vignettes, manual, clean_doc, args,
-                        needs_compilation, compile_attributes, register_routines, quiet, env = parent.frame()) {
+                        needs_compilation, compile_attributes, register_routines, quiet) {
 
   if (!file.exists(path)) {
     stop("`path` must exist", call. = FALSE)
@@ -87,7 +88,6 @@ build_setup <- function(path, dest_path, binary, vignettes, manual, clean_doc, a
 
   if (needs_compilation) {
     update_registration(path, compile_attributes, register_routines, quiet)
-    withr:::local_makevars(compiler_flags(debug = FALSE), assignment = "+=", .local_envir = env)
   }
 
   if (binary) {

--- a/R/compile-dll.R
+++ b/R/compile-dll.R
@@ -49,7 +49,7 @@ compile_dll <- function(path = ".",
     )
   } else {
     # Otherwise set makevars for fast development / debugging
-    withr::with_makevars(compiler_flags(TRUE), assignment = "+=", {
+    withr::with_makevars(compiler_flags(TRUE), .assignment = "+=", {
       install_min(
         path,
         dest = install_dir,

--- a/R/compile-dll.R
+++ b/R/compile-dll.R
@@ -49,7 +49,7 @@ compile_dll <- function(path = ".",
     )
   } else {
     # Otherwise set makevars for fast development / debugging
-    withr::with_makevars(compiler_flags(TRUE), .assignment = "+=", {
+    withr::with_makevars(compiler_flags(TRUE), assignment = "+=", {
       install_min(
         path,
         dest = install_dir,

--- a/R/with-debug.R
+++ b/R/with-debug.R
@@ -43,7 +43,7 @@ without_compiler <- function(code) {
   flags <- c(
     CC = "test",
     CXX = "test",
-    CXX1X = "test",
+    CXX11 = "test",
     FC = "test"
   )
 


### PR DESCRIPTION
Fixes https://github.com/r-lib/pkgdepends/issues/138

