### PR TITLE
debug should also be taken into account with Rtools 4.0

### DIFF
--- a/R/rtools.R
+++ b/R/rtools.R
@@ -32,6 +32,8 @@ has_rtools <- function(debug = FALSE) {
   if(is_R4()){
     rtools40_home <- Sys.getenv('RTOOLS40_HOME', 'C:\\rtools40')
     if(file.exists(file.path(rtools40_home, 'usr', 'bin'))){
+      if (debug)
+        cat("Found in Rtools 4.0 installation folder\n")
       rtools_path_set(rtools(rtools40_home, '4.0'))
       return(TRUE)
     }


### PR DESCRIPTION
Currently, no debut print is done when using 
``` r
library(pkgbuild)
pkgbuild:::is_R4()
#> [1] TRUE
find_rtools(TRUE)
#> [1] TRUE
```

<sup>Created on 2020-09-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

With this PR
``` r
pkgload::load_all()
#> Loading pkgbuild
pkgbuild:::is_R4()
#> [1] TRUE
find_rtools(TRUE)
#> Found in Rtools 4.0 installation folder
#> [1] TRUE
```

<sup>Created on 2020-09-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

The message could be more precise like "Using R >=4.0 and Rtools founds in installation folder (default or set by RTOOLS40_HOME)"
