### PR TITLE
Correction to #120; move NEWS entry to new version heading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pkgbuild
 Title: Find Tools Needed to Build R Packages
-Version: 1.2.0
+Version: 1.2.0.9000
 Authors@R: c(
     person("Hadley", "Wickham", role = "aut"),
     person("Jim", "Hester", , "jim.hester@rstudio.com", role = c("aut", "cre")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,15 @@
+# pkgbuild 1.2.1
+
+* `build_setup_source` now considerers both command-line build arguments, as
+  well as parameters `vignettes` or `manual` when conditionally executing
+  flag-dependent behaviors (@dgkf, #120)
+
 # pkgbuild 1.2.0
 
 * pkgbuild is now licensed as MIT (#106)
 * `compile_dll()` gains a `debug` argument for more control over the compile options used (@richfitz, #100)
 * `pkgbuild_process()` and `build()` now use colored compiler diagnostics if supported (#102)
 * Avoid documentation link ambiguity in R 4.1 (#105)
-* `build_setup_source` now considerers both command-line build arguments, as
-  well as parameters `vignettes` or `manual` when conditionally executing
-  flag-dependent behaviors (@dgkf, #120)
 
 # pkgbuild 1.1.0
 


### PR DESCRIPTION
Sorry for the inconvenience. This is a very minor PR just to touch up a misplaced NEWS entry.

- Moves previous `NEWS` entry to `v1.2.1` version heading
- Updates package version in `DESCRIPTION` to use `.9000` suffix during development of `v1.2.1`
