### PR TITLE
Add option to turn off has_compiler() checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Depends:
     R (>= 3.4)
 Imports:
     callr (>= 3.2.0),
-    cli,
+    cli (>= 3.4.0),
     crayon,
     desc,
     prettyunits,

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -20,8 +20,12 @@
 #' with_build_tools(has_compiler())
 has_compiler <- function(debug = FALSE) {
   res <- getOption("pkgbuild.has_compiler")
-  if (!is.null(res) && is.logical(res) && length(res) == 1 && (res %in% c(TRUE, FALSE))) {
-    return(res)
+  if (!is.null(res)) {
+    if (is.logical(res) && length(res) == 1 && (res %in% c(TRUE, FALSE))) {
+      return(res)
+    }
+    options(pkgbuild.has_compiler = NULL)
+    message("Invalid pkgbuild.has_compiler option. The option was just reset to `NULL`.")
   }
 
   if (!debug && cache_exists("has_compiler")) {

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -26,11 +26,12 @@
 has_compiler <- function(debug = FALSE) {
   res <- getOption("pkgbuild.has_compiler")
   if (!is.null(res)) {
-    if (is.logical(res) && length(res) == 1 && (res %in% c(TRUE, FALSE))) {
-      return(res)
-    }
-    options(pkgbuild.has_compiler = NULL)
-    message("Invalid pkgbuild.has_compiler option. The option was just reset to `NULL`.")
+    if (is_flag(res)) return(res)
+    stop(cli::format_error(c(
+      "",
+      "!" = "Invalid {.code pkgbuild.has_compiler} option.",
+      "i" = "It must be {.code TRUE} or {.code FALSE}, not {.type {res}}."
+    )))
   }
 
   if (!debug && cache_exists("has_compiler")) {

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -1,14 +1,19 @@
 #' Is a compiler available?
 #'
-#' `has_compiler()` and `has_devel()` return `TRUE` or `FALSE`.
-#' `check_devel`
-#' throws an error if you don't have developer tools installed. Implementation
-#' based on a suggestion by Simon Urbanek. End-users (particularly those on
-#' Windows) should generally run [check_build_tools()] rather than
-#' [check_compiler()].
+#' @description
+#' These functions check if a small C file can be compiled, linked, loaded
+#' and executed.
 #'
-#' If the `"pkgbuild.has_compiler"` option is set, no check is carried out,
-#' and the value of the option is returned by `has_compiler()`.
+#' `has_compiler()` and `has_devel()` return `TRUE` or `FALSE`.
+#' `check_compiler()` and `check_devel()`
+#' throw an error if you don't have developer tools installed.
+#' If the `"pkgbuild.has_compiler"` option is set to `TRUE` or `FALSE`,
+#' no check is carried out, and the value of the option is used.
+#'
+#' The implementation is  based on a suggestion by Simon Urbanek.
+#' End-users (particularly those on Windows) should generally run
+#' [check_build_tools()] rather than [check_compiler()].
+#'
 #'
 #' @export
 #' @inheritParams has_rtools

--- a/R/compiler.R
+++ b/R/compiler.R
@@ -1,10 +1,14 @@
 #' Is a compiler available?
 #'
-#' `has_devel` returns `TRUE` or `FALSE`. `check_devel`
+#' `has_compiler()` and `has_devel()` return `TRUE` or `FALSE`.
+#' `check_devel`
 #' throws an error if you don't have developer tools installed. Implementation
 #' based on a suggestion by Simon Urbanek. End-users (particularly those on
 #' Windows) should generally run [check_build_tools()] rather than
 #' [check_compiler()].
+#'
+#' If the `"pkgbuild.has_compiler"` option is set, no check is carried out,
+#' and the value of the option is returned by `has_compiler()`.
 #'
 #' @export
 #' @inheritParams has_rtools
@@ -15,6 +19,11 @@
 #'
 #' with_build_tools(has_compiler())
 has_compiler <- function(debug = FALSE) {
+  res <- getOption("pkgbuild.has_compiler")
+  if (!is.null(res) && is.logical(res) && length(res) == 1 && (res %in% c(TRUE, FALSE))) {
+    return(res)
+  }
+
   if (!debug && cache_exists("has_compiler")) {
     return(cache_get("has_compiler"))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,3 +63,7 @@ last_char <- function(x) {
 cat0 <- function(..., sep = "") {
   cat(..., sep = "")
 }
+
+is_flag <- function(x) {
+  is.logical(x) && length(x) == 1 && !is.na(x)
+}

--- a/man/has_compiler.Rd
+++ b/man/has_compiler.Rd
@@ -15,16 +15,18 @@ check_compiler(debug = FALSE)
 debugging. If \code{FALSE}, it will use result cached from a previous run.}
 }
 \description{
+These functions check if a small C file can be compiled, linked, loaded
+and executed.
+
 \code{has_compiler()} and \code{has_devel()} return \code{TRUE} or \code{FALSE}.
-\code{check_devel}
-throws an error if you don't have developer tools installed. Implementation
-based on a suggestion by Simon Urbanek. End-users (particularly those on
-Windows) should generally run \code{\link[=check_build_tools]{check_build_tools()}} rather than
-\code{\link[=check_compiler]{check_compiler()}}.
-}
-\details{
-If the \code{"pkgbuild.has_compiler"} option is set, no check is carried out,
-and the value of the option is returned by \code{has_compiler()}.
+\code{check_compiler()} and \code{check_devel()}
+throw an error if you don't have developer tools installed.
+If the \code{"pkgbuild.has_compiler"} option is set to \code{TRUE} or \code{FALSE},
+no check is carried out, and the value of the option is used.
+
+The implementation is  based on a suggestion by Simon Urbanek.
+End-users (particularly those on Windows) should generally run
+\code{\link[=check_build_tools]{check_build_tools()}} rather than \code{\link[=check_compiler]{check_compiler()}}.
 }
 \examples{
 has_compiler()

--- a/man/has_compiler.Rd
+++ b/man/has_compiler.Rd
@@ -15,11 +15,16 @@ check_compiler(debug = FALSE)
 debugging. If \code{FALSE}, it will use result cached from a previous run.}
 }
 \description{
-\code{has_devel} returns \code{TRUE} or \code{FALSE}. \code{check_devel}
+\code{has_compiler()} and \code{has_devel()} return \code{TRUE} or \code{FALSE}.
+\code{check_devel}
 throws an error if you don't have developer tools installed. Implementation
 based on a suggestion by Simon Urbanek. End-users (particularly those on
 Windows) should generally run \code{\link[=check_build_tools]{check_build_tools()}} rather than
 \code{\link[=check_compiler]{check_compiler()}}.
+}
+\details{
+If the \code{"pkgbuild.has_compiler"} option is set, no check is carried out,
+and the value of the option is returned by \code{has_compiler()}.
 }
 \examples{
 has_compiler()

--- a/tests/testthat/_snaps/compiler.md
+++ b/tests/testthat/_snaps/compiler.md
@@ -5,5 +5,5 @@
     Error <simpleError>
       
       ! Invalid `pkgbuild.has_compiler` option.
-      ℹ It must be `TRUE` or `FALSE`, not an integer vector.
+      i It must be `TRUE` or `FALSE`, not an integer vector.
 

--- a/tests/testthat/_snaps/compiler.md
+++ b/tests/testthat/_snaps/compiler.md
@@ -1,0 +1,9 @@
+# has_compiler: returns the value of the has_compiler option
+
+    Code
+      has_compiler()
+    Error <simpleError>
+      
+      ! Invalid `pkgbuild.has_compiler` option.
+      ℹ It must be `TRUE` or `FALSE`, not an integer vector.
+

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -1,6 +1,7 @@
 
 describe("has_compiler", {
   withr::local_options(pkgbuild.has_compiler = NULL)
+  testthat::local_reproducible_output()
   it("succeeds if a compiler exists", {
     skip_if(is_windows() && !has_rtools())
     without_cache({

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -1,5 +1,6 @@
 
 describe("has_compiler", {
+  withr::local_options(pkgbuild.has_compiler = NULL)
   it("succeeds if a compiler exists", {
     skip_if(is_windows() && !has_rtools())
     without_cache({
@@ -32,6 +33,13 @@ describe("has_compiler", {
           expect_false(has_compiler())
           expect_error(check_compiler(), "Failed to compile C code")
         }
+      )
+      withr::with_options(
+        list(pkgbuild.has_compiler = 1:2),
+        expect_snapshot(
+          error = TRUE,
+          has_compiler()
+        )
       )
     })
   })

--- a/tests/testthat/test-compiler.R
+++ b/tests/testthat/test-compiler.R
@@ -12,4 +12,27 @@ describe("has_compiler", {
       expect_true(check_compiler())
     })
   })
+
+  it("returns the value of the has_compiler option", {
+    skip_if(is_windows() && !has_rtools())
+    without_cache({
+      without_compiler({
+        withr::with_options(
+          c(pkgbuild.has_compiler = TRUE),
+          {
+            expect_true(has_compiler())
+            expect_error(check_compiler(), NA)
+          }
+        )
+      })
+      cache_reset()
+      withr::with_options(
+        c(pkgbuild.has_compiler = FALSE),
+        {
+          expect_false(has_compiler())
+          expect_error(check_compiler(), "Failed to compile C code")
+        }
+      )
+    })
+  })
 })


### PR DESCRIPTION
These can be misleading, e.g., in the presence of antivirus programs on Windows.