### PR TITLE
pkgbuild can now avoid copying large package trees

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     crayon,
     desc,
     prettyunits,
+    processx,
     R6,
     rprojroot,
     withr (>= 2.3.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # pkgbuild development version
 
+* pkgbuild can now avoid copying large package directories when building a
+  source package. See the `PKG_BUILD_COPY_METHOD` enviroment variable in
+  `?build` or the package README (#59).
+
+  This is currently an experimental feature, and feedback is
+  appreciated.
+
 * `R CMD build` warnings can now be turned into errors, by setting the
   `pkg.build_stop_for_warnings` option to `TRUE` or by setting the
   `PKG_BUILD_STOP_FOR_WARNINGS` environment variable to `true` (#114).

--- a/R/build.R
+++ b/R/build.R
@@ -17,7 +17,29 @@
 #'   `inst/doc` when building a source package. Set it to `TRUE` to force a
 #'   cleanup. See the `clean_doc` argument.
 #'
+#' * `Config/build/copy-method` can be used to avoid copying large
+#'   directories in `R CMD build`. It works by copying (or linking) the
+#'   files of the package to a temporary directory, leaving out the
+#'   (possibly large) files that are not part of the package. Possible
+#'   values:
+#'
+#'   - `none`: pkgbuild does not copy the package tree. This is the default.
+#'   - `copy`: the package files are copied to a temporary directory before
+#'     ` R CMD build`.
+#'   - `link`: the package files are symbolic linked to a temporary
+#'     directory before `R CMD build`. Windows does not have symbolic
+#'     links, so on Windows this is equivalent to `copy`.
+#'
+#'   You can also use the `pkg.build_copy_method` option or the
+#'   `PKG_BUILD_COPY_METHOD` environment variable to set the copy method.
+#'   The option is consulted first, then the `DESCRIPTION` entry, then the
+#'   environment variable.
+#'
 #' ### Options
+#'
+#' * `pkg.build_copy_method`: use this option to avoid copying large
+#'   directories when building a package. See possible values above, at the
+#'   `Config/build/copy-method` `DESCRIPTION` entry.
 #'
 #' * `pkg.build_stop_for_warnings`: if it is set to `TRUE`, then pkgbuild
 #'   will stop for `R CMD build` errors. It takes precedence over the
@@ -29,7 +51,10 @@
 #'  compiler diagnostics. Set it to `true` to force colored compiler
 #'  diagnostics.
 #'
-#' * `PKG_BUILD_STOP_FOR_WARNINGS`: if it is set to `true`, then pkgbuild
+#' * `PKG_BUILD_COPY_METHOD`: use this environment variable to avoid copying
+#'   large directories when building a package. See possible values above,
+#'   at the `Config/build/copy-method` `DESCRIPTION` entry.
+#'
 #' will stop for `R CMD build` errors. The `pkg.build_stop_for_warnings`
 #' option takes precedence over this environment variable.
 #'
@@ -211,6 +236,15 @@ build_setup_source <- function(path, dest_path, vignettes, manual, clean_doc,
   # Build in temporary directory and then copy to final location
   out_dir <- tempfile()
   dir.create(out_dir)
+
+  copy_method <- get_copy_method(path)
+
+  if (copy_method != "none") {
+    pkgname <- desc::desc_get("Package", path)
+    tmppath <- tempfile("build-")
+    copy_package_tree(path, tmppath, pkgname)
+    path <- file.path(tmppath, pkgname)
+  }
 
   list(
     cmd = "build",

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -1,0 +1,323 @@
+
+copy_package_tree <- function(
+  path = ".",
+  dest,
+  pkgname = desc::desc_get("Package", path)) {
+
+  if (!file.exists(dest)) mkdirp(dest)
+
+  pkgdir <- file.path(dest, pkgname)
+  if (file.exists(pkgdir)) {
+    stop(cli::format_error(c(
+      "Cannot copy package tree to {.path {dest}}",
+      i = "Directory {.path {pkgdir}} already exists, and did not want
+          to overwrite."
+    )))
+  }
+
+  mkdirp(pkgdir)
+
+  paths <- build_files(path, pkgname)
+
+  method <- get_copy_method(path)
+
+  for (i in seq_len(nrow(paths))) {
+    # excluded, skip
+    if (paths$exclude[i]) next
+    if (paths$isdir[i] && paths$trimmed[i]) {
+      # trimmed directory, only create directory
+      # we do not try to update the mode of the directory, as it is not
+      # very important for R packages, and it might fail on some file
+      # systems.
+      mkdirp(file.path(pkgdir, paths$path[i]))
+    } else {
+      # not a directory, or a non-trimmed directory, recurse
+      src <- paths$realpath[i]
+      tgt <- file.path(pkgdir, paths$path[i])
+      if (method == "link") {
+        file.symlink(src, tgt)
+      } else if (paths$isdir[i]) {
+        cp(src, dirname(tgt), recursive = TRUE)
+      } else {
+        cp(src, tgt)
+      }
+    }
+  }
+
+  # TODO: should we return a trimming summary?
+  invisible()
+}
+
+get_copy_method <- function(path = ".") {
+  method <- getOption("pkg.build_copy_method", NA_character_)
+  values <- c("none", "copy", "link")
+  check_method <- function(method) {
+    # no symlinks on Windows
+    if (method == "link" && is_windows()) method <- "copy"
+    if (method %in% values) return(method)
+    stop(cli::format_error(c(
+      "Invalid {.code pkg.build_copy_method} value: {.val {method}}.",
+      i = "It must be one of {.str {values}}."
+    )))
+  }
+  if (!is_string(method) && !is_na(method)) {
+    stop(cli::format_error(c(
+      "Invalid {.code pkg.build_copy_method} value.",
+      i = "It must be a string, but it is {.type {method}}."
+    )))
+  }
+  if (!is.na(method)) return(check_method(method))
+
+  method <- desc::desc_get("Config/build/copy-method", path)
+  if (!is.na(method)) return(check_method(method))
+
+  method <- Sys.getenv("PKG_BUILD_COPY_METHOD", "none")
+  check_method(method)
+}
+
+build_files <- function(
+  path = ".",
+  pkgname = desc::desc_get("Package", path)) {
+
+  path <- normalizePath(path)
+
+  # patterns in .Rbuildignore
+  ign_file <- file.path(path, ".Rbuildignore")
+  ign <- if (file.exists(ign_file)) {
+    readLines(ign_file, warn = FALSE)
+  } else {
+    character()
+  }
+  ign <- ign[nzchar(ign)]
+  # make it case insensitive, that's how R matches them
+  if (length(ign)) ign <- paste0("(?i)", ign)
+
+  ptrn <- c(ign, re_exclude(pkgname))
+  ptrn_dir <- re_exclude_dir(pkgname)
+
+  # filter at the top level first, so we don't need to enumerate these
+  top <- dir(path, include.dirs = TRUE, all.files=TRUE, no.. = TRUE)
+
+  # now filter top
+  realtop <- file.path(path, top)
+  topfls <- data.frame(
+    stringsAsFactors = FALSE,
+    path = top,
+    realpath = realtop,
+    exclude = logical(length(top)),
+    isdir = file.info(realtop)$isdir
+  )
+  topfls <- exclude(path, topfls, ptrn, ptrn_dir)
+
+  # now create the rest of the files
+  sub <- unlist(lapply(
+    topfls$path[topfls$isdir & !topfls$exclude],
+    function(t) {
+      tf <- dir(file.path(path, t), include.dirs = TRUE, all.files = TRUE,
+                recursive = TRUE)
+      tf <- file.path(t, tf)
+    }
+  ))
+
+  realsub <- file.path(path, sub)
+  subfls <- data.frame(
+    stringsAsFactors = FALSE,
+    path = sub,
+    realpath = realsub,
+    exclude = logical(length(sub)),
+    isdir = file.info(realsub)$isdir
+  )
+  subfls <- exclude(path, subfls, ptrn, ptrn_dir)
+
+  allfls <- rbind(topfls, subfls)
+
+  # Always keep this, so base R can do its own filtering, just in case
+  # it changes compared to ours
+  allfls$exclude[allfls$path == ".Rbuildignore"] <- FALSE
+
+  allfls <- exclude_downstream(allfls)
+
+  allfls
+}
+
+re_exclude <- function(pkg) {
+  c(
+    paste0(
+      "(?i)",                               # these are case insensitive
+      c(
+        "(^|/)\\.DS_Store$",                # by macOS finder
+        "^\\.RData$",                       # .RData at /
+        "~$", "\\.bak$", "\\.swp$",         # backup files
+        "(^|/)\\.#[^/]*$", "(^|/)#[^/]*#$", # more backup files (Emacs)
+
+        "^config\\.(cache|log|status)$",    # leftover by autoconf
+        "(^|/)autom4te\\.cache$",
+
+        "^src/.*\\.d$", "^src/Makedeps$",   # INSTALL leftover on Windows
+
+        "^inst/doc/Rplots\\.(ps|pdf)$"      # Sweave leftover
+      )
+    ),
+
+    "(^|/)\\._[^/]*$",                      # macOS resource forks
+
+    paste0(                                 # hidden files
+      "(^|/)\\.",
+      c("Renviron",
+        "Rprofile",
+        "Rproj.user",
+        "Rhistory",
+        "Rapp.history",
+        "tex",
+        "log",
+        "aux",
+        "pdf",
+        "png",
+        "backups",
+        "cvsignore",
+        "cproject",
+        "directory",
+        "dropbox",
+        "exrc",
+        "gdb.history",
+        "gitattributes",
+        "github",
+        "gitignore",
+        "gitmodules",
+        "hgignore",
+        "hgtags",
+        "htaccess",
+        "latex2html-init",
+        "project",
+        "seed",
+        "settings",
+        "tm_properties"
+      ),
+      "$"
+    ),
+
+    paste0(
+      "(^|/)",
+      pkg,
+      "_[0-9.-]+",
+      "\\.(tar\\.gz|tar|tar\\.bz2|tar\\.xz|tgz|zip)",
+      "$"
+    )
+  )
+}
+
+re_exclude_dir <- function(pkg) {
+  c(
+    "^revdep$",                             # revdepcheck
+    paste0(                                 # VC
+      "(^|/)",
+      c("CVS",
+        ".svn",
+        ".arch-ids",
+        ".bzr",
+        ".git",
+        ".hg",
+        "_darcs",
+        ".metadata"
+      ),
+      "$"
+    ),
+
+    "(^|/)[^/]*[Oo]ld$",
+    "(^|/)[^/]*\\.Rcheck",
+
+    "^src.*/\\.deps$"
+  )
+}
+
+exclude <- function(root, paths, patterns, patterns_dir) {
+  ex <- logical(nrow(paths))
+  for (p in patterns) {
+    ex <- ex | grepl(p, paths$path, perl = TRUE)
+  }
+
+  # additional regexes for directories, we don't need to check 'ex'
+  wdirs <- !ex & paths$isdir
+
+  paths_dirs <- paths$path[wdirs]
+  dex <- logical(length(paths_dirs))
+  for (p in patterns_dir) {
+    dex <- dex | grepl(p, paths_dirs, perl = TRUE)
+  }
+  ex[wdirs][dex] <- TRUE
+
+  paths$exclude <- ex
+  paths
+}
+
+exclude_downstream <- function(paths) {
+  # We don't actually need this now, but we could use it to optimize,
+  # because we could trim only the subsequent elements after a directory.
+  paths <- paths[order(paths$path), ]
+
+  # We need to take each excluded directory, and remove all paths in them
+  exdirs <- paste0(paths$path[paths$isdir & paths$exclude], "/")
+  del <- logical(nrow(paths))
+  for (ed in exdirs) {
+    del <- del | startsWith(paths$path, ed)
+  }
+  paths <- paths[!del, ]
+
+  # Now we mark the subdirectories that can be copied as is, i.e. none of
+  # their downstream contents are excluded
+  indirs <- which(paths$isdir & !paths$exclude)
+  trm <- logical(nrow(paths))
+  for (id in indirs) {
+    trm[id] <- any(
+      startsWith(paths$path, paste0(paths$path[id], "/")) & paths$exclude
+    )
+  }
+  paths$trimmed <- trm
+
+  # We can remove the subdirectories of non-trimmed directories as well
+  fulldirs <- paste0(paths$path[paths$isdir & !trm], "/")
+  del2 <- logical(nrow(paths))
+  for (fd in fulldirs) {
+    del2 <- del2 | startsWith(paths$path, fd)
+  }
+  paths <- paths[!del2, ]
+
+  rownames(paths) <- NULL
+  paths
+}
+
+cp <- local({
+  windows <- NULL
+  cpargs <- NULL
+  function(src, tgt, recursive = FALSE) {
+    if (is.null(windows)) windows <<- is_windows()
+    if (windows) {
+      if (!file.copy(src, tgt, recursive = recursive, copy.date = TRUE)) {
+        stop(cli::format_error(c(
+          "Could not copy package files.",
+          i = "Failed to copy {.path {src}} to {.path {tgt}}."
+        )))
+      }
+
+    } else {
+      if (is.null(cpargs)) cpargs <<- detect_cp_args()
+      processx::run("cp", c(cpargs, src, tgt))
+    }
+  }
+})
+
+detect_cp_args <- function() {
+  f1 <- tempfile()
+  f2 <- tempfile()
+  on.exit(unlink(c(f1, f2)), add = TRUE)
+  file.create(f1)
+  tryCatch(
+    suppressWarnings(processx::run("cp", c("--preserve=timestamps", f1, f2))),
+    error = function(e) e
+  )
+  if (file.exists(f2)) {
+    c("-LR", "--preserve=timestamps")
+  } else {
+    "-pLR"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,28 @@ pkgbuild::with_build_tools(my_code)
   `inst/doc` when building a source package. Set it to `TRUE` to force a
   cleanup. See the `clean_doc` argument of `build()` as well.
 
+* `Config/build/copy-method` can be used to avoid copying large directories
+  in `R CMD build`. It works by copying (or linking) the files of the
+  package to a temporary directory, leaving out the (possibly large) files
+  that are not part of the package. Possible values:
+
+  - `none`: pkgbuild does not copy the package tree. This is the default.
+  - `copy`: the package files are copied to a temporary directory before
+    ` R CMD build`.
+  - `link`: the package files are symbolic linked to a temporary directory
+    before `R CMD build`. Windows does not have symbolic links, so on Windows
+    this is equivalent to `copy`.
+
+  You can also use the `pkg.build_copy_method` option or the
+  `PKG_BUILD_COPY_METHOD` environment variable to set the copy method.
+  The option is consulted first, then the `DESCRIPTION` entry, then the
+  environment variable.
+
 ### Options
+
+* `pkg.build_copy_method`: use this option to avoid copying large directories
+  when building a package. See possible values above, at the
+  `Config/build/copy-method` `DESCRIPTION` entry.
 
 * `pkg.build_stop_for_warnings`: if it is set to `TRUE`, then pkgbuild will stop
   for `R CMD build` errors. It takes precedence over the
@@ -49,6 +70,10 @@ pkgbuild::with_build_tools(my_code)
 * `PKG_BUILD_COLOR_DIAGNOSTICS`: set it to `false` to opt out of colored
   compiler diagnostics. Set it to `true` to force colored compiler
   diagnostics.
+
+* `PKG_BUILD_COPY_METHOD`: use this environment variable to avoid copying
+  large directories when building a package. See possible values above,
+  at the `Config/build/copy-method` `DESCRIPTION` entry.
 
 * `PKG_BUILD_STOP_FOR_WARNINGS`: if it is set to `true`, then pkgbuild will stop
   for `R CMD build` errors. The `pkg.build_stop_for_warnings` option takes

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -81,11 +81,32 @@ environment is needed.
 \item \code{Config/build/clean-inst-doc} can be set to \code{FALSE} to avoid cleaning up
 \code{inst/doc} when building a source package. Set it to \code{TRUE} to force a
 cleanup. See the \code{clean_doc} argument.
+\item \code{Config/build/copy-method} can be used to avoid copying large
+directories in \verb{R CMD build}. It works by copying (or linking) the
+files of the package to a temporary directory, leaving out the
+(possibly large) files that are not part of the package. Possible
+values:
+\itemize{
+\item \code{none}: pkgbuild does not copy the package tree. This is the default.
+\item \code{copy}: the package files are copied to a temporary directory before
+\verb{ R CMD build}.
+\item \code{link}: the package files are symbolic linked to a temporary
+directory before \verb{R CMD build}. Windows does not have symbolic
+links, so on Windows this is equivalent to \code{copy}.
+}
+
+You can also use the \code{pkg.build_copy_method} option or the
+\code{PKG_BUILD_COPY_METHOD} environment variable to set the copy method.
+The option is consulted first, then the \code{DESCRIPTION} entry, then the
+environment variable.
 }
 }
 
 \subsection{Options}{
 \itemize{
+\item \code{pkg.build_copy_method}: use this option to avoid copying large
+directories when building a package. See possible values above, at the
+\code{Config/build/copy-method} \code{DESCRIPTION} entry.
 \item \code{pkg.build_stop_for_warnings}: if it is set to \code{TRUE}, then pkgbuild
 will stop for \verb{R CMD build} errors. It takes precedence over the
 \code{PKG_BUILD_STOP_FOR_WARNINGS} environment variable.
@@ -97,10 +118,13 @@ will stop for \verb{R CMD build} errors. It takes precedence over the
 \item \code{PKG_BUILD_COLOR_DIAGNOSTICS}: set it to \code{false} to opt out of colored
 compiler diagnostics. Set it to \code{true} to force colored compiler
 diagnostics.
-\item \code{PKG_BUILD_STOP_FOR_WARNINGS}: if it is set to \code{true}, then pkgbuild
+\item \code{PKG_BUILD_COPY_METHOD}: use this environment variable to avoid copying
+large directories when building a package. See possible values above,
+at the \code{Config/build/copy-method} \code{DESCRIPTION} entry.
+}
+
 will stop for \verb{R CMD build} errors. The \code{pkg.build_stop_for_warnings}
 option takes precedence over this environment variable.
-}
 }
 
 }

--- a/tests/testthat/_snaps/exclude.md
+++ b/tests/testthat/_snaps/exclude.md
@@ -1,0 +1,80 @@
+# copy_package_tree creates package dir
+
+    Code
+      sort(dir(tmp, recursive = TRUE, include.dirs = TRUE))
+    Output
+      [1] "testDummy"             "testDummy/DESCRIPTION" "testDummy/NAMESPACE"  
+      [4] "testDummy/R"           "testDummy/R/a.r"       "testDummy/R/b.r"      
+
+---
+
+    Code
+      sort(dir(tmp, recursive = TRUE, include.dirs = TRUE))
+    Output
+      [1] "testDummy"             "testDummy/DESCRIPTION" "testDummy/NAMESPACE"  
+      [4] "testDummy/R"           "testDummy/R/a.r"       "testDummy/R/b.r"      
+
+# exclusions
+
+    Code
+      files[, c("path", "exclude", "isdir", "trimmed")]
+    Output
+                  path exclude isdir trimmed
+      1         .RData    TRUE FALSE   FALSE
+      2  .Rbuildignore   FALSE FALSE   FALSE
+      3      .Rhistory    TRUE FALSE   FALSE
+      4           .git    TRUE  TRUE   FALSE
+      5    DESCRIPTION   FALSE FALSE   FALSE
+      6           docs    TRUE  TRUE   FALSE
+      7            src   FALSE  TRUE    TRUE
+      8  src/.DS_Store    TRUE FALSE   FALSE
+      9  src/foo.c.bak    TRUE FALSE   FALSE
+      10 src/foo.c.swp    TRUE FALSE   FALSE
+      11    src/foo.c~    TRUE FALSE   FALSE
+      12     src/foo.d    TRUE FALSE   FALSE
+      13     src/src.c   FALSE FALSE   FALSE
+      14     src/src.o    TRUE FALSE   FALSE
+
+# Ignoring .Rbuildignore
+
+    Code
+      files[, c("path", "exclude", "isdir", "trimmed")]
+    Output
+                 path exclude isdir trimmed
+      1 .Rbuildignore   FALSE FALSE   FALSE
+      2   DESCRIPTION   FALSE FALSE   FALSE
+      3          docs    TRUE  TRUE   FALSE
+      4           src   FALSE  TRUE    TRUE
+      5     src/src.c   FALSE FALSE   FALSE
+      6     src/src.o    TRUE FALSE   FALSE
+
+# copying on windows
+
+    Code
+      sort(dir(tmp, recursive = TRUE, include.dirs = TRUE))
+    Output
+      [1] "testDummy"             "testDummy/DESCRIPTION" "testDummy/NAMESPACE"  
+      [4] "testDummy/R"           "testDummy/R/a.r"       "testDummy/R/b.r"      
+
+# cp error
+
+    Code
+      cp("foo", "bar")
+    Error <simpleError>
+      Could not copy package files.
+      i Failed to copy 'foo' to 'bar'.
+
+# detect_cp_args
+
+    Code
+      detect_cp_args()
+    Output
+      [1] "-pLR"
+
+---
+
+    Code
+      detect_cp_args()
+    Output
+      [1] "-LR"                   "--preserve=timestamps"
+

--- a/tests/testthat/test-exclude.R
+++ b/tests/testthat/test-exclude.R
@@ -1,0 +1,151 @@
+
+test_that("copy_package_tree creates package dir", {
+  tmp <- withr::local_tempdir("pkgbuild-test-")
+
+  # link
+  withr::local_options(pkg.build_copy_method = "link")
+  unlink(tmp, recursive = TRUE)
+  expect_no_warning(
+    copy_package_tree(test_path("testDummy"), tmp)
+  )
+  expect_snapshot(
+    sort(dir(tmp, recursive = TRUE, include.dirs = TRUE))
+  )
+
+  # copy
+  withr::local_options(pkg.build_copy_method = "copy")
+  unlink(tmp, recursive = TRUE)
+  expect_no_warning(
+    copy_package_tree(test_path("testDummy"), tmp)
+  )
+  expect_snapshot(
+    sort(dir(tmp, recursive = TRUE, include.dirs = TRUE))
+  )
+})
+
+test_that("copy_package_tree errors", {
+  tmp <- withr::local_tempdir("pkgbuild-test-")
+  mkdirp(file.path(tmp, "testDummy"))
+  expect_error(
+    copy_package_tree(test_path("testDummy"), tmp),
+    "already exists"
+  )
+})
+
+test_that("exclusions", {
+  pkgdir <- file.path(withr::local_tempdir("pkgbuild-test-"), "pkg")
+  mkdirp(pkgdir)
+  writeLines(
+    c("Package: pkg", "Version: 1.0.0"),
+    file.path(pkgdir, "DESCRIPTION")
+  )
+
+  # create some structure with files to ignore and keep
+  writeLines(c(
+    "^docs$",
+    "^src/.*[.]o$"
+  ), file.path(pkgdir, ".Rbuildignore"))
+
+  mkdirp(file.path(pkgdir, "src"))
+  file.create(file.path(pkgdir, "src", "src.c"))
+  file.create(file.path(pkgdir, "src", "src.o"))
+  mkdirp(file.path(pkgdir, "docs"))
+  file.create(file.path(pkgdir, "docs", "foo"))
+
+  file.create(file.path(pkgdir, "src", ".DS_Store"))
+  file.create(file.path(pkgdir, ".Rhistory"))
+  file.create(file.path(pkgdir, ".RData"))
+  file.create(file.path(pkgdir, "src", "foo.c~"))
+  file.create(file.path(pkgdir, "src", "foo.c.bak"))
+  file.create(file.path(pkgdir, "src", "foo.c.swp"))
+  file.create(file.path(pkgdir, "src", "foo.d"))
+  dir.create(file.path(pkgdir, ".git"))
+  file.create(file.path(pkgdir, ".git", "foo"))
+
+  files <- build_files(pkgdir)
+  expect_snapshot(files[, c("path", "exclude", "isdir", "trimmed")])
+
+  dest <- withr::local_tempdir("pkgbuild-test-")
+  copy_package_tree(pkgdir, dest)
+})
+
+test_that("get_copy_method", {
+  mockery::stub(get_copy_method, "is_windows", TRUE)
+  withr::local_options(pkg.build_copy_method = "link")
+  expect_equal(get_copy_method(), "copy")
+
+  withr::local_options(pkg.build_copy_method = "foobar")
+  expect_error(get_copy_method(), "pkg.build_copy_method")
+
+  withr::local_options(pkg.build_copy_method = 1:10)
+  expect_error(get_copy_method(), "It must be a string")
+
+  withr::local_options(pkg.build_copy_method = NULL)
+  mockery::stub(get_copy_method, "desc::desc_get", "link")
+  expect_equal(get_copy_method(), "copy")
+})
+
+test_that("Ignoring .Rbuildignore", {
+  pkgdir <- file.path(withr::local_tempdir("pkgbuild-test-"), "pkg")
+  mkdirp(pkgdir)
+  writeLines(
+    c("Package: pkg", "Version: 1.0.0"),
+    file.path(pkgdir, "DESCRIPTION")
+  )
+
+  # create some structure with files to ignore and keep
+  writeLines(c(
+    "^docs$",
+    "^src/.*[.]o$",
+    "^\\.Rbuildignore$"
+  ), file.path(pkgdir, ".Rbuildignore"))
+
+  mkdirp(file.path(pkgdir, "src"))
+  file.create(file.path(pkgdir, "src", "src.c"))
+  file.create(file.path(pkgdir, "src", "src.o"))
+  mkdirp(file.path(pkgdir, "docs"))
+  file.create(file.path(pkgdir, "docs", "foo"))
+
+  files <- build_files(pkgdir)
+  expect_snapshot(files[, c("path", "exclude", "isdir", "trimmed")])
+})
+
+test_that("copying on windows", {
+  # this works on Unix as well
+  environment(cp)$windows <- TRUE
+  on.exit(environment(cp)$windows <- NULL, add = TRUE)
+  tmp <- withr::local_tempdir("pkgbuild-test-")
+
+  # link
+  withr::local_options(pkg.build_copy_method = "copy")
+  unlink(tmp, recursive = TRUE)
+  expect_no_warning(
+    copy_package_tree(test_path("testDummy"), tmp)
+  )
+  expect_snapshot(
+    sort(dir(tmp, recursive = TRUE, include.dirs = TRUE))
+  )
+})
+
+test_that("cp error", {
+  environment(cp)$windows <- TRUE
+  on.exit(environment(cp)$windows <- NULL, add = TRUE)
+  withr::local_dir(withr::local_tempdir())
+  expect_snapshot(error = TRUE, cp("foo", "bar"))
+})
+
+test_that("detect_cp_args", {
+  mockery::stub(
+    detect_cp_args,
+    "processx::run",
+    function(...) stop("nope")
+  )
+  expect_snapshot(detect_cp_args())
+
+  mockery::stub(
+    detect_cp_args,
+    "processx::run",
+    function(f1, f2) file.create(f2)
+  )
+  expect_snapshot(detect_cp_args())
+})


### PR DESCRIPTION
This is currently an opt-in feature, and you need to set the `PKG_BUILD_COPY_METHOD=link` environment variable ot turn it on. It can also be configured via an option or a `DESCRIPTION` entry. See `?build` or `README.md`.

Closes #59.