### PR TITLE
Better debugging for compile_dll()

### DIFF
--- a/R/compile-dll.R
+++ b/R/compile-dll.R
@@ -49,6 +49,7 @@ compile_dll <- function(path = ".",
 
   if (should_add_compiler_flags()) {
     withr::local_makevars(compiler_flags(debug), .assignment = "+=")
+    if (debug) withr::local_envvar(DEBUG = "true")
   }
 
   install_min(

--- a/R/compile-dll.R
+++ b/R/compile-dll.R
@@ -7,6 +7,30 @@
 #'
 #' Invisibly returns the names of the DLL.
 #'
+#' ## Configuration
+#'
+#' ### Options
+#'
+#' * `pkg.build_extra_flags`: set this to `FALSE` to to opt out from adding
+#'   debug compiler flags in `compile_dll()`. Takes precedence over the
+#'   `PKG_BUILD_EXTRA_FLAGS` environment variable. Possible values:
+#'
+#'   - `TRUE`: add extra flags,
+#'   - `FALSE`: do not add extra flags,
+#'   - `"missing"`: add extra flags if the user does not have a
+#'     `$HOME/.R/Makevars` file.
+#'
+#' ### Environment variables
+#'
+#' * `PKG_BUILD_EXTRA_FLAGS`: set this to `false` to to opt out from adding
+#'   debug compiler flags in `compile_dll()`. The `pkg.build_extra_flags` option
+#'   takes precedence over this environment variable. Possible values:
+#'
+#'   - `"true"`: add extra flags,
+#'   - `"false"`: do not add extra flags,
+#'   - `"missing"`: add extra flags if the user does not have a
+#'     `$HOME/.R/Makevars` file.
+#'
 #' @note If this is used to compile code that uses Rcpp, you will need to
 #'   add the following line to your `Makevars` file so that it
 #'   knows where to find the Rcpp headers:

--- a/R/utils.R
+++ b/R/utils.R
@@ -116,6 +116,42 @@ should_stop_for_warnings <- function() {
   get_config_flag_value("stop_for_warnings")
 }
 
+isFALSE <- function (x) {
+  is.logical(x) && length(x) == 1L && !is.na(x) && !x
+}
+
+should_add_compiler_flags <- function() {
+  val <- getOption("pkg.build_extra_flags", NULL)
+  if (isTRUE(val)) return(TRUE)
+  if (isFALSE(val)) return(FALSE)
+  if (identical(val, "missing")) return(length(makevars_user()) == 0)
+  if (!is.null(val)) {
+    if (!is_string(val)) {
+      stop(cli::format_error(c(
+        "Invalid {.code pkg.build_extra_flags} option.",
+        i = "It must be {.code TRUE}, {.code FALSE} or {.str missing}, not
+             {.type {val}}."
+      )))
+    } else {
+      stop(cli::format_error(c(
+        "Invalid {.code pkg_build_extra_flags} option.",
+        i = "It must be {.code TRUE}, {.code FALSE} or {.str missing}, not
+            {.str {val}}."
+      )))
+    }
+  }
+
+  val <- Sys.getenv("PKG_BUILD_EXTRA_FLAGS", "true")
+  if (val %in% flag_true_values) return(TRUE)
+  if (val %in% flag_false_values) return(FALSE)
+  if (val %in% "missing") return(length(makevars_user()) == 0)
+
+  stop(cli::format_error(c(
+    "Invalid {.envvar PKG_BUILD_EXTRA_FLAGS} environment variable.",
+    i = "Must be one of {.code true}, {.code false} or {.code missing}."
+  )))
+}
+
 get_desc_config_flag <- function(path, name) {
   name <- paste0("Config/build/", name)
   val <- desc::desc_get(name, file = path)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ pkgbuild::with_build_tools(my_code)
   when building a package. See possible values above, at the
   `Config/build/copy-method` `DESCRIPTION` entry.
 
+* `pkg.build_extra_flags`: set this to `FALSE` to to opt out from adding
+  debug compiler flags in `compile_dll()`. Takes precedence over the
+  `PKG_BUILD_EXTRA_FLAGS` environment variable. Possible values:
+
+  - `TRUE`: add extra flags,
+  - `FALSE`: do not add extra flags,
+  - `"missing"`: add extra flags if the user does not have a
+    `$HOME/.R/Makevars` file.
+
 * `pkg.build_stop_for_warnings`: if it is set to `TRUE`, then pkgbuild will stop
   for `R CMD build` errors. It takes precedence over the
   `PKG_BUILD_STOP_FOR_WARNINGS` environment variable.
@@ -74,6 +83,15 @@ pkgbuild::with_build_tools(my_code)
 * `PKG_BUILD_COPY_METHOD`: use this environment variable to avoid copying
   large directories when building a package. See possible values above,
   at the `Config/build/copy-method` `DESCRIPTION` entry.
+
+* `PKG_BUILD_EXTRA_FLAGS`: set this to `false` to to opt out from adding
+  debug compiler flags in `compile_dll()`. The `pkg.build_extra_flags` option
+  takes precedence over this environment variable. Possible values:
+
+  - `"true"`: add extra flags,
+  - `"false"`: do not add extra flags,
+  - `"missing"`: add extra flags if the user does not have a
+    `$HOME/.R/Makevars` file.
 
 * `PKG_BUILD_STOP_FOR_WARNINGS`: if it is set to `true`, then pkgbuild will stop
   for `R CMD build` errors. The `pkg.build_stop_for_warnings` option takes

--- a/man/compile_dll.Rd
+++ b/man/compile_dll.Rd
@@ -43,6 +43,36 @@ During compilation, debug flags are set with
 }
 \details{
 Invisibly returns the names of the DLL.
+\subsection{Configuration}{
+\subsection{Options}{
+\itemize{
+\item \code{pkg.build_extra_flags}: set this to \code{FALSE} to to opt out from adding
+debug compiler flags in \code{compile_dll()}. Takes precedence over the
+\code{PKG_BUILD_EXTRA_FLAGS} environment variable. Possible values:
+\itemize{
+\item \code{TRUE}: add extra flags,
+\item \code{FALSE}: do not add extra flags,
+\item \code{"missing"}: add extra flags if the user does not have a
+\verb{$HOME/.R/Makevars} file.
+}
+}
+}
+
+\subsection{Environment variables}{
+\itemize{
+\item \code{PKG_BUILD_EXTRA_FLAGS}: set this to \code{false} to to opt out from adding
+debug compiler flags in \code{compile_dll()}. The \code{pkg.build_extra_flags} option
+takes precedence over this environment variable. Possible values:
+\itemize{
+\item \code{"true"}: add extra flags,
+\item \code{"false"}: do not add extra flags,
+\item \code{"missing"}: add extra flags if the user does not have a
+\verb{$HOME/.R/Makevars} file.
+}
+}
+}
+
+}
 }
 \note{
 If this is used to compile code that uses Rcpp, you will need to

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,24 @@
+# should_add_compiler_flags errors
+
+    Code
+      should_add_compiler_flags()
+    Error <simpleError>
+      Invalid `pkg.build_extra_flags` option.
+      i It must be `TRUE`, `FALSE` or "missing", not an integer vector.
+
+---
+
+    Code
+      should_add_compiler_flags()
+    Error <simpleError>
+      Invalid `pkg_build_extra_flags` option.
+      i It must be `TRUE`, `FALSE` or "missing", not "foobar".
+
+---
+
+    Code
+      should_add_compiler_flags()
+    Error <simpleError>
+      Invalid `PKG_BUILD_EXTRA_FLAGS` environment variable.
+      i Must be one of `true`, `false` or `missing`.
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -28,3 +28,98 @@ test_that("should_stop_for_warnings", {
   withr::local_envvar(PKG_BUILD_STOP_FOR_WARNINGS = "foobar")
   expect_error(should_stop_for_warnings(), "environment variable must be")
 })
+
+test_that("isFALSE", {
+  pos <- list(FALSE, structure(FALSE, class = "foo"))
+  neg <- list(1, c(FALSE, TRUE), NA, list(FALSE))
+  for (p in pos) expect_true(isFALSE(p), info = p)
+  for (n in neg) expect_false(isFALSE(n), info = n)
+})
+
+test_that("should_add_compiler_flags", {
+  # should not be called if option is set
+  mockery::stub(
+    should_add_compiler_flags,
+    "makevars_user",
+    function() stop("dont")
+  )
+
+  # options is TRUE
+  withr::local_options(pkg.build_extra_flags = TRUE)
+  expect_true(should_add_compiler_flags())
+
+  # options is FALSE
+  withr::local_options(pkg.build_extra_flags = FALSE)
+  expect_false(should_add_compiler_flags())
+
+  # depends on whether Makevars exists
+  withr::local_options(pkg.build_extra_flags = "missing")
+  mockery::stub(
+    should_add_compiler_flags,
+    "makevars_user",
+    function() character()
+  )
+  expect_true(should_add_compiler_flags())
+  mockery::stub(
+    should_add_compiler_flags,
+    "makevars_user",
+    function() "foobar"
+  )
+  withr::local_options(pkg.build_extra_flags = "missing")
+  expect_false(should_add_compiler_flags())
+
+  mockery::stub(
+    should_add_compiler_flags,
+    "makevars_user",
+    function() stop("dont")
+  )
+  withr::local_options(pkg.build_extra_flags = NULL)
+
+  # env var true
+  withr::local_envvar(PKG_BUILD_EXTRA_FLAGS = "true")
+  expect_true(should_add_compiler_flags())
+
+  # env var false
+  withr::local_envvar(PKG_BUILD_EXTRA_FLAGS = "false")
+  expect_false(should_add_compiler_flags())
+
+  # depends on whether Makevars exists
+  withr::local_envvar(PKG_BUILD_EXTRA_FLAGS = "missing")
+  mockery::stub(
+    should_add_compiler_flags,
+    "makevars_user",
+    function() character()
+  )
+  expect_true(should_add_compiler_flags())
+  mockery::stub(
+    should_add_compiler_flags,
+    "makevars_user",
+    function() "foobar"
+  )
+  expect_false(should_add_compiler_flags())
+
+  # no option or env var, then TRUE
+  mockery::stub(
+    should_add_compiler_flags,
+    "makevars_user",
+    function() stop("dont")
+  )
+  withr::local_options(pkg.build_extra_flags = NULL)
+  withr::local_envvar(PKG_BUILD_EXTRA_FLAGS = NA_character_)
+  expect_true(should_add_compiler_flags())
+})
+
+test_that("should_add_compiler_flags errors", {
+  # invalid option type
+  withr::local_options(pkg.build_extra_flags = 1:10)
+  expect_snapshot(error = TRUE, should_add_compiler_flags())
+
+  # invalid option value
+  withr::local_options(pkg.build_extra_flags = "foobar")
+  expect_snapshot(error = TRUE, should_add_compiler_flags())
+
+  # invalid env var value
+  withr::local_options(pkg.build_extra_flags = NULL)
+  withr::local_envvar(PKG_BUILD_EXTRA_FLAGS = "foo")
+  expect_snapshot(error = TRUE, should_add_compiler_flags())
+})


### PR DESCRIPTION
- Message includes if debug build or not.
- Add debug options to debug builds even if
  user has a Makevars file, unless they opt out.
- Debug flags are set on Windows.

Closes #135.