### PR TITLE
Run bootstrap.R file on build if present and specified in Config/build

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -165,6 +165,19 @@ build_setup <- function(path, dest_path, binary, vignettes, manual, clean_doc, a
     dest_path <- dirname(path)
   }
 
+  bootstrap_file <- file.path(path, "bootstrap.R")
+  run_boostrap <- isTRUE(get_desc_config_flag(path, "bootstrap"))
+  if (file.exists(bootstrap_file) && run_boostrap) {
+    if (!quiet) message("Running bootstrap.R...")
+
+    callr::rscript(
+      bootstrap_file,
+      wd = path,
+      stderr = "2>&1",
+      show = !quiet
+    )
+  }
+
   if (needs_compilation) {
     update_registration(path, compile_attributes, register_routines, quiet)
   }

--- a/R/build.R
+++ b/R/build.R
@@ -41,6 +41,10 @@
 #'   or globs. (See [utils::glob2rx()].) E.g. `src/rust/src/*.rs` or
 #'   `configure*`.
 #'
+#' * `Config/build/bootstrap` can be set to `TRUE` to run
+#'   `Rscript bootstrap.R` in the source directory prior to running subsequent
+#'   build steps.
+#'
 #' ### Options
 #'
 #' * `pkg.build_copy_method`: use this option to avoid copying large

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -104,6 +104,9 @@ for pkgbuild to decide whether a package DLL needs to be recompiled in
 \code{needs_compile()}. The syntax is a comma separated list of file names,
 or globs. (See \code{\link[utils:glob2rx]{utils::glob2rx()}}.) E.g. \verb{src/rust/src/*.rs} or
 \verb{configure*}.
+\item \code{Config/build/bootstrap} can be set to \code{TRUE} to run
+\verb{Rscript bootstrap.R} in the source directory prior to running subsequent
+build steps.
 }
 }
 


### PR DESCRIPTION
For https://github.com/r-lib/pkgdepends/issues/303 . Basically, I'm spending a lot of time working in repositories that share sources between Python and R packages and it would be nice if the pak-based tooling worked out-of-the box for things like `Remotes:` dependencies and check/build/install actions.

The general approach is:

- Look for `bootstrap.R` and `Config/build/bootstrap: TRUE`
- Use `callr::rscript()` to run `boostrap.R` with the working directory set to the source directory

The DESCRIPTION Config option is nice because it makes the opt-in more explicit (in the event that bootstrap.R existed in the package directory already) and because there was already a place to document Config/build options.

As @gaborcsardi pointed out, using `Rscript` + "boostrap.R" is more portable than a shell script because Rtools might not be installed or on the PATH.

This approach doesn't help with `R CMD INSTALL pkg_directory` but package authors can always do `$R_HOME/bin/Rscript bootstrap.R` in `configure` and/or `configure.win`, which also would work with `devtools::load_all()` (I think).