### PR TITLE
Update pkgdown

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -32,7 +32,6 @@ jobs:
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
-          pak-version: rc
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
@@ -40,7 +39,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false
           branch: gh-pages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Description: Provides functions used to build R packages. Locates
     compilers needed to build R packages on various platforms and ensures
     the PATH is configured appropriately so R can use them.
 License: MIT + file LICENSE
-URL: https://github.com/r-lib/pkgbuild, https://r-lib.github.io/pkgbuild/
+URL: https://github.com/r-lib/pkgbuild,
+    https://pkgbuild.r-lib.org
 BugReports: https://github.com/r-lib/pkgbuild/issues
 Depends: 
     R (>= 3.4)
@@ -36,5 +37,5 @@ Suggests:
 Config/Needs/website: tidyverse/tidytemplate
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1.9000
+RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,11 +1,10 @@
-url: https://r-lib.github.io/pkgbuild/
-
+url: https://pkgbuild.r-lib.org
 template:
   package: tidytemplate
   bootstrap: 5
   includes:
     in_header: |
-      <script defer data-domain="r-lib.github.io/pkgbuild,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
-
+      <script defer data-domain="pkgbuild.r-lib.org/pkgbuild,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 development:
   mode: auto
+

--- a/man/pkgbuild-package.Rd
+++ b/man/pkgbuild-package.Rd
@@ -12,7 +12,7 @@ Provides functions used to build R packages. Locates compilers needed to build R
 Useful links:
 \itemize{
   \item \url{https://github.com/r-lib/pkgbuild}
-  \item \url{https://r-lib.github.io/pkgbuild/}
+  \item \url{https://pkgbuild.r-lib.org}
   \item Report bugs at \url{https://github.com/r-lib/pkgbuild/issues}
 }
 


### PR DESCRIPTION
Following the checklist at [tidytemplate](https://github.com/tidyverse/tidytemplate#updating)

* [x] `usethis::use_pkgdown_github_pages()`
* [x] Ensure Author includes RStudio as copyright holder and funder
* [x] Update `DESCRIPTION` to include `Config/Needs/website: tidyverse/tidytemplate`
* [x] Update `_pkgdown.yml` with appropriate template above.
* [x] Ping Hadley to add plausible.io record
* [ ] ~Remove `strip_header: true`~
* [ ] ~Remove algolia search, if used~
* [ ] ~Eliminate superseded navbar customisation (`home: ~`, article re-ordering)~
* [ ] ~Update `news` structure if needed~
* [ ] ~Remove any author info for tidyverse folks (since now included in template)~

CNAME record not obtained yet - I will update the custom domain in settings (to pkgbuild.r-lib.org) once we have the CNAME and this is merged