### PR TITLE
Fix for rtools_path() failing on R for Windows on ARM (R AARCH64) - 3 filepaths accidentally missing a second backslash

### DIFF
--- a/R/rtools.R
+++ b/R/rtools.R
@@ -32,7 +32,7 @@ has_rtools <- function(debug = FALSE) {
 
   # R 4.5.0 or later on ARM64
   if (getRversion() >= "4.5.0" && grepl("aarch", R.version$platform)) {
-    rtools45_aarch64_home <- Sys.getenv("RTOOLS45_AARCH64_HOME", "C:\rtools45-aarch64")
+    rtools45_aarch64_home <- Sys.getenv("RTOOLS45_AARCH64_HOME", "C:\\rtools45-aarch64")
     if (file.exists(file.path(rtools45_aarch64_home, "usr", "bin"))) {
       if (debug) {
         cat("Found in Rtools 4.5 (aarch64) installation folder\n")
@@ -57,7 +57,7 @@ has_rtools <- function(debug = FALSE) {
   # R 4.4.0 or later on ARM64
   if (getRversion() >= "4.4.0" && getRversion() < "4.5.0" &&
       grepl("aarch", R.version$platform)) {
-    rtools44_aarch64_home <- Sys.getenv("RTOOLS44_AARCH64_HOME", "C:\rtools44-aarch64")
+    rtools44_aarch64_home <- Sys.getenv("RTOOLS44_AARCH64_HOME", "C:\\rtools44-aarch64")
     if (file.exists(file.path(rtools44_aarch64_home, "usr", "bin"))) {
       if (debug) {
         cat("Found in Rtools 4.4 (aarch64) installation folder\n")
@@ -83,7 +83,7 @@ has_rtools <- function(debug = FALSE) {
   # R 4.3.0 or later on ARM64
   if (getRversion() >= "4.3.0" && getRversion() < "4.4.0" &&
       grepl("aarch", R.version$platform)) {
-    rtools43_aarch64_home <- Sys.getenv("RTOOLS43_AARCH64_HOME", "C:\rtools43-aarch64")
+    rtools43_aarch64_home <- Sys.getenv("RTOOLS43_AARCH64_HOME", "C:\\rtools43-aarch64")
     if (file.exists(file.path(rtools43_aarch64_home, "usr", "bin"))) {
       if (debug) {
         cat("Found in Rtools 4.3 (aarch64) installation folder\n")


### PR DESCRIPTION
I noticed on the new GitHub `windows-11-arm` runner that `devtools::check()` fails because of what I think is this simple little bug in `pkgbuild::rtools_path()` - three filepaths are accidentally missing a second backslash.

Without the fix, the error message one sees is:

```
Error in get(name, envir = cache) : object 'rtools_path' not found
Calls: <Anonymous> -> cache_get -> get
Execution halted
```

Here you can see a GitHub Actions run with the error: 

<https://github.com/remlapmot/pkgbuild-test/actions/runs/14597607865/job/40947417646#step:2:4999>

Here you can see a GitHub Actions runs complete successfully with this small fix:

<https://github.com/remlapmot/pkgbuild-test/actions/runs/14597791955/job/40948043436#step:2:5024>

<https://github.com/remlapmot/pkgbuild-test/actions/runs/14598013275/job/40948802415#step:2:7900>
