### PR TITLE
feat: Add `Config/build/never-clean` option to never clean during build

### DIFF
--- a/R/compile-dll.R
+++ b/R/compile-dll.R
@@ -209,6 +209,11 @@ needs_compile <- function(path = ".") {
 # Does the package need a clean compile?
 # (i.e. is there a header or Makevars newer than the dll)
 needs_clean <- function(path = ".") {
+  never_clean <- get_desc_config_flag(path, "never-clean")
+  if (isTRUE(never_clean)) {
+    return(FALSE)
+  }
+
   headers <- mtime(headers(path))
   # no headers, so never needs clean compile
   if (is.null(headers)) {


### PR DESCRIPTION
Is this something you would support? Happy to add documentation. Do we need a test?

My use cases are duckdb and igraph -- if I need a clean rebuild, I clean, otherwise I'm happy with incremental compiles. The auto-clean gets triggered too frequently, I'm frustrated by it more often than not. The `bootstrap.R` script doesn't seem to get run with `load_all()` .