### PR TITLE
`callr::rcmd_process_options`: use `libpath` argument

### DIFF
--- a/R/build-bg.R
+++ b/R/build-bg.R
@@ -165,6 +165,7 @@ rcb_init <- function(
         cmd = options$cmd,
         cmdargs = c(options$path, options$args),
         wd = options$out_dir,
+        libpath = .libPaths(),
         stderr = "2>&1"
       )
 


### PR DESCRIPTION
An attempt to fix https://github.com/r-lib/rcmdcheck/issues/236

I still got error regarding the libpath and the https://github.com/r-lib/rcmdcheck/pull/196 was not enough. `rcmdcheck` pass the libpaths correctly but it is not picked up inside `pkgbuild` (and the default libpath is used instead). 

I does fix my use case. @gaborcsardi please check if this fixes yours and let me know if anything is needed from my side!