### PR TITLE
Clarify clean_doc build documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pkgbuild (development version)
 
+* The `build()` documentation now describes the `clean_doc = FALSE` and
+  non-interactive `clean_doc = NULL` behavior (#187).
+
 * `needs_compile()` now ignores `.gcov` code coverage files.
 
 # pkgbuild 1.4.8

--- a/R/build.R
+++ b/R/build.R
@@ -101,11 +101,12 @@
 #'   `tools::package_native_routine_registration_skeleton()` before building
 #'   the package. It is ignored if package does not need compilation.
 #' @param clean_doc If `TRUE`, clean the files in `inst/doc` before building
-#'   the package. If `NULL` and the `Config/build/clean-inst-doc` entry is
-#'   present in `DESCRIPTION`, then that is used. Otherwise, if `NULL`,
-#'   and interactive, ask to remove the files prior to cleaning. In most
-#'   cases cleaning the files is the correct behavior to avoid stale
-#'   vignette outputs in the built package.
+#'   the package. If `FALSE`, leave `inst/doc` unchanged. If `NULL` and the
+#'   `Config/build/clean-inst-doc` entry is present in `DESCRIPTION`, then that
+#'   value is used. Otherwise, if `NULL` and interactive, ask before removing
+#'   the files; if `NULL` and non-interactive, clean the files. In most cases
+#'   cleaning the files is the correct behavior to avoid stale vignette outputs
+#'   in the built package.
 #' @export
 #' @return a string giving the location (including file name) of the built
 #'  package

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -36,11 +36,12 @@ If \code{NULL}, it defaults to the parent directory of the package.}
 vignettes (\code{--no-build-vignettes}) or manual (\code{--no-manual}).}
 
 \item{clean_doc}{If \code{TRUE}, clean the files in \code{inst/doc} before building
-the package. If \code{NULL} and the \code{Config/build/clean-inst-doc} entry is
-present in \code{DESCRIPTION}, then that is used. Otherwise, if \code{NULL},
-and interactive, ask to remove the files prior to cleaning. In most
-cases cleaning the files is the correct behavior to avoid stale
-vignette outputs in the built package.}
+the package. If \code{FALSE}, leave \code{inst/doc} unchanged. If \code{NULL} and the
+\code{Config/build/clean-inst-doc} entry is present in \code{DESCRIPTION}, then that
+value is used. Otherwise, if \code{NULL} and interactive, ask before removing
+the files; if \code{NULL} and non-interactive, clean the files. In most cases
+cleaning the files is the correct behavior to avoid stale vignette outputs
+in the built package.}
 
 \item{args}{An optional character vector of additional command
 line arguments to be passed to \verb{R CMD build} if \code{binary = FALSE},


### PR DESCRIPTION
Fixes #187.

This clarifies the `build(clean_doc = )` documentation for the currently implemented branches:

- `FALSE` leaves `inst/doc` unchanged
- `NULL` uses `Config/build/clean-inst-doc` when present
- if still `NULL`, interactive sessions ask before removing files, while non-interactive sessions clean them

Checks:
- `Rscript -e 'tools::checkRd("man/build.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `R_LIBS_USER=/tmp/cli-r-lib _R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests pkgbuild_1.4.8.9000.tar.gz`