### PR TITLE
Add -mbig-obj flag for windows debug builds

### DIFF
--- a/R/compiler-flags.R
+++ b/R/compiler-flags.R
@@ -59,6 +59,19 @@ compiler_flags <- function(debug = FALSE) {
     )
     res[flags] <- paste(res[flags], "-fdiagnostics-color=always")
   }
+
+  if (debug && .Platform$OS.type == "windows") {
+    flags <- c(
+      "CFLAGS",
+      "CXXFLAGS",
+      "CXX11FLAGS",
+      "CXX14FLAGS",
+      "CXX17FLAGS",
+      "CXX20FLAGS"
+    )
+    # Debug symbols can generate too many sections on Windows
+    res[flags] <- paste(res[flags], "-Wa,-mbig-obj")
+  }
   res
 }
 


### PR DESCRIPTION
A long-standing gripe for windows devs of stan-based R packages is the [`too many sections` error when using `devtools::load_all()`](https://discourse.mc-stan.org/search?q=too%20many%20sections), caused by compiling packages with debug symbols and no optimisation.

Traditionally, we've just advised users to add the `-Wa,-mbig-obj` flag to their Makevars when developing, but the queries are still raised and there can be confusion about when to remove the flag.

Adding the flag in `pkgbuild` directly would be a big help (both for user experience and reducing queries!)

Thanks!